### PR TITLE
responseDTO 와 errorResponseDTO 추가하였습니다. 

### DIFF
--- a/src/main/java/com/fastcampus/toyproject/common/dto/ErrorResponseDTO.java
+++ b/src/main/java/com/fastcampus/toyproject/common/dto/ErrorResponseDTO.java
@@ -1,0 +1,28 @@
+package com.fastcampus.toyproject.common.dto;
+
+import com.fastcampus.toyproject.common.exception.ExceptionCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import static com.fastcampus.toyproject.common.exception.ExceptionCode.INTERNAL_SERVER_ERROR;
+@Getter
+@RequiredArgsConstructor
+public class ErrorResponseDTO {
+    private final ExceptionCode exceptionCode;
+    private final String errorMsg;
+
+    public static ErrorResponseDTO error(ExceptionCode exceptionCode, String errorMsg) {
+        return new ErrorResponseDTO(exceptionCode, errorMsg);
+    }
+
+    public static ErrorResponseDTO error() {
+        return new ErrorResponseDTO(INTERNAL_SERVER_ERROR, INTERNAL_SERVER_ERROR.getMsg());
+    }
+
+
+    /*
+    에러 발생시 사용 예시
+    ResponseEntity<ErrorResponse>
+    return new ResponseEntity<ErrorResponse.error(코드, 메시지)>;
+     */
+}

--- a/src/main/java/com/fastcampus/toyproject/common/dto/ResponseDTO.java
+++ b/src/main/java/com/fastcampus/toyproject/common/dto/ResponseDTO.java
@@ -1,0 +1,26 @@
+package com.fastcampus.toyproject.common.dto;
+
+import lombok.*;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public class ResponseDTO<T> {
+    private final HttpStatus status;
+    private final String msg;
+    private final T data;
+
+    public static <T> ResponseDTO<T> ok(String msg, T data) {
+        return new ResponseDTO<>(HttpStatus.OK, msg, data);
+    }
+
+    public static <T> ResponseDTO<Void> ok(String msg) {
+        return new ResponseDTO<>(HttpStatus.OK, msg, null);
+    }
+
+    public static <T> ResponseDTO<Void> ok() {
+        return new ResponseDTO<>(HttpStatus.OK, null, null);
+    }
+
+
+}

--- a/src/main/java/com/fastcampus/toyproject/common/exception/DefaultException.java
+++ b/src/main/java/com/fastcampus/toyproject/common/exception/DefaultException.java
@@ -1,11 +1,21 @@
 package com.fastcampus.toyproject.common.exception;
 
-public class DefaultException extends RuntimeException{
+import lombok.Getter;
 
-    public DefaultException() {
+@Getter
+public class DefaultException extends RuntimeException {
+
+    ExceptionCode errorCode;
+    String errorMsg;
+
+    public DefaultException(ExceptionCode errorCode, String errorMsg) {
+        super(errorCode.getMsg());
+        this.errorCode = errorCode;
+        this.errorMsg = errorMsg;
     }
 
-    public DefaultException(String message) {
-        super(message);
+    public DefaultException(ExceptionCode errorCode) {
+        super(errorCode.getMsg());
+        this.errorCode = errorCode;
     }
 }

--- a/src/main/java/com/fastcampus/toyproject/common/exception/DefaultExceptionHandler.java
+++ b/src/main/java/com/fastcampus/toyproject/common/exception/DefaultExceptionHandler.java
@@ -1,0 +1,66 @@
+package com.fastcampus.toyproject.common.exception;
+
+import com.fastcampus.toyproject.common.dto.ErrorResponseDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import javax.servlet.http.HttpServletRequest;
+
+@Slf4j
+@RestControllerAdvice
+public class DefaultExceptionHandler {
+
+    /**
+     * 예상한 예외들 잡는 곳
+     * @param e
+     * @param request
+     * @return
+     */
+    @ExceptionHandler(DefaultException.class)
+    public ResponseEntity<ErrorResponseDTO> handleDefaultException(
+            DefaultException e,
+            HttpServletRequest request
+    ) {
+        log.error("error!!!! errorCode : {}, url : {}, message : {}",
+                e.getErrorCode(),
+                request.getRequestURI(),
+                e.getErrorMsg()
+        );
+
+        return new ResponseEntity<>(
+                ErrorResponseDTO.error(
+                        e.getErrorCode(),
+                        e.getMessage()),
+                HttpStatus.CONFLICT
+        );
+    }
+
+    /**
+     * 커스텀 에러를 제외한 나머지 에러들 처리 (추후 수정 예정) -> badRequset 만 중점으로 받을지 고민됨
+     * @param
+     * @param request
+     * @return
+     */
+    @ExceptionHandler(value = {
+            HttpRequestMethodNotSupportedException.class,
+            MethodArgumentNotValidException.class,
+            Exception.class
+    })
+    public ResponseEntity<ErrorResponseDTO> handleBadRequest(
+            Exception e, HttpServletRequest request
+    ) {
+        log.error("error!!!! url : {}, message : {}",
+                request.getRequestURI(),
+                e.getMessage()
+        );
+
+        return new ResponseEntity<>(
+                ErrorResponseDTO.error(),
+                HttpStatus.INTERNAL_SERVER_ERROR
+        );
+    }
+}

--- a/src/main/java/com/fastcampus/toyproject/common/exception/ExceptionCode.java
+++ b/src/main/java/com/fastcampus/toyproject/common/exception/ExceptionCode.java
@@ -1,0 +1,15 @@
+package com.fastcampus.toyproject.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum ExceptionCode {
+    NO_ITINERARY("해당되는 여정이 없습니다."),
+    INTERNAL_SERVER_ERROR("서버에 오류가 발생했습니다."),
+    INVALID_REQUEST("잘못된 요청입니다.")
+    ;
+
+    private String msg;
+}


### PR DESCRIPTION
## 개요
* 응답을 편하게 보내기 위한 responseDTO 및 errorResponseDTO 생성. 
* enum 클래스인 ExceptionCode 추가. -> <b> 에러 발생할 것 같은거 코드, 메시지로 넣어주세요! </b>

## 작업사항
* responseDTO 와 errorResponseDTO 추가했습니다. 
* 또한 에러 코드 및 에러 처리 클래스를 추가/수정하였습니다. 

## 변경로직

### 변경전
* 기존 ResponseEntity만 사용 하는 것에서 수정하였습니다.

### 변경후
* ResponseDTO : 데이터와 메시지 편하게 보낼 수 있도록함.
* ErrorResponseDTO : 에러 메시지 및 코드를 편하게 보내도록 함.
* ExceptionCode : 사용자 정의 에러 코드 
* DefaultExceptionHandler : 에러 잡는 곳 + 회의중 나왔던 에러 수정하여 올렸습니다.


## 사용방법

### 성공적인 결과 (에러 없는 곳 : 컨트롤러)
Response.ok(데이터, 메시지) 담아서 보냄.
![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/59862752/59d00525-02a2-4d15-a7ec-10a031e06141)

### 에러 잡는 곳
ResponseEntity에 감싸서 보냄. 
![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/59862752/078b23b4-7046-4402-a1a9-48d7257d1620)


## 기타
* 에러 response 와 일반 response 형식이 다름. -> 추후 수정하거나 리팩토링해야할 것 같습니다. 