### PR TITLE
[Feat] ERROR로그 관리를 위해 로깅을 적용했습니다.

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <include resource="org/springframework/boot/logging/logback/base.xml"/>
+  <property name="LOGS" value="./logs" />
+
+  <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+    <layout class="ch.qos.logback.classic.PatternLayout">
+      <Pattern>
+        %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
+      </Pattern>
+    </layout>
+  </appender>
+
+  <appender name="RollingFile" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${LOGS}/spring-boot-logger.log</file>
+    <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+      <Pattern>
+        %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
+      </Pattern>
+    </encoder>
+
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>${LOGS}/archived/spring-boot-logger-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+        <maxFileSize>10MB</maxFileSize>
+      </timeBasedFileNamingAndTriggeringPolicy>
+      <maxHistory>20</maxHistory>
+    </rollingPolicy>
+  </appender>
+
+  <root level="ERROR">
+    <appender-ref ref="Console" />
+    <appender-ref ref="RollingFile" />
+  </root>
+</configuration>


### PR DESCRIPTION
## ERROR로그 관리를 위해 로깅을 적용했습니다.

-  작업사항 : error가 발생할 경우만 로그를 확인할 수 있도록 logback-spring.xml 생성
- ./logs 디렉토리에 에러 로그만 저장하도록 설정했습니다. 루트 디렉토리 아래의 'logs'폴더에서 확인할 수 있습니다.
- 로거 : SLF4J

-----
적용하시면 앞으로 에러 로그만 모아볼 수 있습니다! 에러 원인 파악하는 것에 도움이 되실 거예요!
