### PR TITLE
여정 관련 클래스들 (요청 DTO, 컨트롤러, 서비스, 레포지토리) 추가 및 여정 순서 검증 메소드 추가하였어요

### DIFF
--- a/src/main/java/com/fastcampus/toyproject/common/config/JPAConfig.java
+++ b/src/main/java/com/fastcampus/toyproject/common/config/JPAConfig.java
@@ -1,0 +1,9 @@
+package com.fastcampus.toyproject.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JPAConfig {
+}

--- a/src/main/java/com/fastcampus/toyproject/common/exception/ExceptionCode.java
+++ b/src/main/java/com/fastcampus/toyproject/common/exception/ExceptionCode.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 @Getter
 public enum ExceptionCode {
     NO_ITINERARY("해당되는 여정이 없습니다."),
+    DUPLICATE_ITINERARY_OEDER("여정 순서가 중복됩니다."),
+    INCORRECT_ORDER("잘못된 여정 순서입니다."),
     INTERNAL_SERVER_ERROR("서버에 오류가 발생했습니다."),
     INVALID_REQUEST("잘못된 요청입니다.")
     ;

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/controller/ItineraryContoller.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/controller/ItineraryContoller.java
@@ -1,8 +1,12 @@
 package com.fastcampus.toyproject.domain.itinerary.controller;
 
+import com.fastcampus.toyproject.domain.itinerary.service.ItineraryService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
 
+@RequiredArgsConstructor
 @RestController
 public class ItineraryContoller {
+    private final ItineraryService itineraryService;
 
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/controller/ItineraryContoller.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/controller/ItineraryContoller.java
@@ -2,10 +2,12 @@ package com.fastcampus.toyproject.domain.itinerary.controller;
 
 import com.fastcampus.toyproject.domain.itinerary.service.ItineraryService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
+@RequestMapping("/itineraries")
 public class ItineraryContoller {
     private final ItineraryService itineraryService;
 

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/controller/ItineraryController.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/controller/ItineraryController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/itineraries")
-public class ItineraryContoller {
+public class ItineraryController {
     private final ItineraryService itineraryService;
 
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryDTO.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryDTO.java
@@ -3,6 +3,7 @@ package com.fastcampus.toyproject.domain.itinerary.dto;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import lombok.*;
@@ -30,6 +31,10 @@ public class ItineraryDTO {
 
     @NotNull
     private LocalDateTime endDate;
+
+    @NotNull
+    @Min(1)
+    private Integer order;
 
     private String departurePlace;
     private String arrivalPlace;

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryDTO.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryDTO.java
@@ -1,0 +1,37 @@
+package com.fastcampus.toyproject.domain.itinerary.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@ToString
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ItineraryDTO {
+
+    @NotNull
+    @Size(min = 1, max = 3)
+    private Integer type;
+
+    @NotNull
+    private String name;
+
+    @NotNull
+    private LocalDateTime startDate;
+
+    @NotNull
+    private LocalDateTime endDate;
+
+    private String departurePlace;
+    private String arrivalPlace;
+
+}

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryRequestDTO.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryRequestDTO.java
@@ -17,7 +17,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class ItineraryDTO {
+public class ItineraryRequestDTO {
 
     @NotNull
     @Size(min = 1, max = 3)

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Lodgement.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Lodgement.java
@@ -1,4 +1,4 @@
-package com.fastcampus.toyproject.domain.lodgement.entity;
+package com.fastcampus.toyproject.domain.itinerary.entity;
 
 import com.fastcampus.toyproject.domain.itinerary.entity.Itinerary;
 import java.time.LocalDateTime;

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Movement.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Movement.java
@@ -1,4 +1,4 @@
-package com.fastcampus.toyproject.domain.stay.entity;
+package com.fastcampus.toyproject.domain.itinerary.entity;
 
 import java.time.LocalDateTime;
 import javax.persistence.Entity;
@@ -13,11 +13,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Stay {
+public class Movement {
 
     @Id
     private Long id;
     private LocalDateTime departureDate;
     private LocalDateTime arrivalDate;
-
+    private String departurePlace;
+    private String arrivalPlace;
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Stay.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Stay.java
@@ -1,4 +1,4 @@
-package com.fastcampus.toyproject.domain.movement.entity;
+package com.fastcampus.toyproject.domain.itinerary.entity;
 
 import java.time.LocalDateTime;
 import javax.persistence.Entity;
@@ -13,12 +13,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Movement {
+public class Stay {
 
     @Id
     private Long id;
     private LocalDateTime departureDate;
     private LocalDateTime arrivalDate;
-    private String departurePlace;
-    private String arrivalPlace;
+
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/repository/ItineraryRepository.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/repository/ItineraryRepository.java
@@ -1,0 +1,6 @@
+package com.fastcampus.toyproject.domain.itinerary.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ItineraryRepository<Itinerary> extends JpaRepository<Itinerary, Long> {
+}

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/repository/LodgementRepository.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/repository/LodgementRepository.java
@@ -1,9 +1,9 @@
 package com.fastcampus.toyproject.domain.itinerary.repository;
 
-import com.fastcampus.toyproject.domain.itinerary.entity.Itinerary;
+import com.fastcampus.toyproject.domain.itinerary.entity.Lodgement;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ItineraryRepository extends JpaRepository<Itinerary, Long> {
+public interface LodgementRepository extends JpaRepository<Lodgement, Long> {
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/repository/MovementRepository.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/repository/MovementRepository.java
@@ -1,9 +1,9 @@
 package com.fastcampus.toyproject.domain.itinerary.repository;
 
-import com.fastcampus.toyproject.domain.itinerary.entity.Itinerary;
+import com.fastcampus.toyproject.domain.itinerary.entity.Movement;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ItineraryRepository extends JpaRepository<Itinerary, Long> {
+public interface MovementRepository extends JpaRepository<Movement, Long> {
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/repository/StayRepository.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/repository/StayRepository.java
@@ -1,9 +1,9 @@
 package com.fastcampus.toyproject.domain.itinerary.repository;
 
-import com.fastcampus.toyproject.domain.itinerary.entity.Itinerary;
+import com.fastcampus.toyproject.domain.itinerary.entity.Stay;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ItineraryRepository extends JpaRepository<Itinerary, Long> {
+public interface StayRepository extends JpaRepository<Stay, Long> {
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
@@ -1,6 +1,9 @@
 package com.fastcampus.toyproject.domain.itinerary.service;
 
 import com.fastcampus.toyproject.domain.itinerary.repository.ItineraryRepository;
+import com.fastcampus.toyproject.domain.itinerary.repository.LodgementRepository;
+import com.fastcampus.toyproject.domain.itinerary.repository.MovementRepository;
+import com.fastcampus.toyproject.domain.itinerary.repository.StayRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -8,6 +11,8 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class ItineraryService {
-
     private final ItineraryRepository itineraryRepository;
+    private final LodgementRepository lodgementRepository;
+    private final MovementRepository movementRepository;
+    private final StayRepository stayRepository;
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
@@ -1,0 +1,13 @@
+package com.fastcampus.toyproject.domain.itinerary.service;
+
+import com.fastcampus.toyproject.domain.itinerary.repository.ItineraryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class ItineraryService {
+
+    private final ItineraryRepository itineraryRepository;
+}

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryValidation.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryValidation.java
@@ -1,0 +1,4 @@
+package com.fastcampus.toyproject.domain.itinerary.util;
+
+public class ItineraryValidation {
+}

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryValidation.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryValidation.java
@@ -1,7 +1,7 @@
 package com.fastcampus.toyproject.domain.itinerary.util;
 
 import com.fastcampus.toyproject.common.exception.DefaultException;
-import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryDTO;
+import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryRequestDTO;
 
 import java.util.*;
 
@@ -16,9 +16,9 @@ public class ItineraryValidation {
      * @param : itineraryDTOList
      * @return
      */
-    public static void validateItinerariesOrder(List<ItineraryDTO> itineraryDTOList) {
+    public static void validateItinerariesOrder(List<ItineraryRequestDTO> itineraryRequestDTOList) {
         //1. 순서가 중복되는지 검사하고, 순서대로 정렬. (O(NlogN))
-        Collections.sort(itineraryDTOList, (o1, o2) -> {
+        Collections.sort(itineraryRequestDTOList, (o1, o2) -> {
            if (o1.getOrder() == o2.getOrder()) {
                throw new DefaultException(DUPLICATE_ITINERARY_OEDER);
            }
@@ -26,8 +26,8 @@ public class ItineraryValidation {
         });
 
         //2. 순서가 1부터 차례대로 들어갔는지 확인. (O(N))
-        for (int orderIdx = 1; orderIdx <= itineraryDTOList.size(); orderIdx++) {
-            if (itineraryDTOList.get(orderIdx - 1).getOrder() != orderIdx) {
+        for (int orderIdx = 1; orderIdx <= itineraryRequestDTOList.size(); orderIdx++) {
+            if (itineraryRequestDTOList.get(orderIdx - 1).getOrder() != orderIdx) {
                 throw new DefaultException(INCORRECT_ORDER);
             }
         }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryValidation.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryValidation.java
@@ -1,7 +1,6 @@
 package com.fastcampus.toyproject.domain.itinerary.util;
 
 import com.fastcampus.toyproject.common.exception.DefaultException;
-import com.fastcampus.toyproject.common.exception.ExceptionCode;
 import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryDTO;
 
 import java.util.*;
@@ -14,12 +13,12 @@ public class ItineraryValidation {
     /**
      * 여정 순서가 적절하게 입력되었는지 확인하는 메소드
      * @author : 지운
-     * @param list
+     * @param : itineraryDTOList
      * @return
      */
-    public static void validateItinerariesOrder(List<ItineraryDTO> list) {
+    public static void validateItinerariesOrder(List<ItineraryDTO> itineraryDTOList) {
         //1. 순서가 중복되는지 검사하고, 순서대로 정렬. (O(NlogN))
-        Collections.sort(list, (o1, o2) -> {
+        Collections.sort(itineraryDTOList, (o1, o2) -> {
            if (o1.getOrder() == o2.getOrder()) {
                throw new DefaultException(DUPLICATE_ITINERARY_OEDER);
            }
@@ -27,8 +26,8 @@ public class ItineraryValidation {
         });
 
         //2. 순서가 1부터 차례대로 들어갔는지 확인. (O(N))
-        for (int orderIdx = 1; orderIdx <= list.size(); orderIdx++) {
-            if (list.get(orderIdx - 1).getOrder() != orderIdx) {
+        for (int orderIdx = 1; orderIdx <= itineraryDTOList.size(); orderIdx++) {
+            if (itineraryDTOList.get(orderIdx - 1).getOrder() != orderIdx) {
                 throw new DefaultException(INCORRECT_ORDER);
             }
         }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryValidation.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryValidation.java
@@ -1,4 +1,37 @@
 package com.fastcampus.toyproject.domain.itinerary.util;
 
+import com.fastcampus.toyproject.common.exception.DefaultException;
+import com.fastcampus.toyproject.common.exception.ExceptionCode;
+import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryDTO;
+
+import java.util.*;
+
+import static com.fastcampus.toyproject.common.exception.ExceptionCode.DUPLICATE_ITINERARY_OEDER;
+import static com.fastcampus.toyproject.common.exception.ExceptionCode.INCORRECT_ORDER;
+
 public class ItineraryValidation {
+
+    /**
+     * 여정 순서가 적절하게 입력되었는지 확인하는 메소드
+     * @author : 지운
+     * @param list
+     * @return
+     */
+    public static void validateItinerariesOrder(List<ItineraryDTO> list) {
+        //1. 순서가 중복되는지 검사하고, 순서대로 정렬. (O(NlogN))
+        Collections.sort(list, (o1, o2) -> {
+           if (o1.getOrder() == o2.getOrder()) {
+               throw new DefaultException(DUPLICATE_ITINERARY_OEDER);
+           }
+           return o1.getOrder() - o2.getOrder();
+        });
+
+        //2. 순서가 1부터 차례대로 들어갔는지 확인. (O(N))
+        for (int orderIdx = 1; orderIdx <= list.size(); orderIdx++) {
+            if (list.get(orderIdx - 1).getOrder() != orderIdx) {
+                throw new DefaultException(INCORRECT_ORDER);
+            }
+        }
+    }
+
 }

--- a/src/test/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryValidationTest.java
+++ b/src/test/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryValidationTest.java
@@ -1,7 +1,6 @@
 package com.fastcampus.toyproject.domain.itinerary.util;
 
 import com.fastcampus.toyproject.common.exception.DefaultException;
-import com.fastcampus.toyproject.common.exception.ExceptionCode;
 import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryDTO;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,6 +46,7 @@ class ItineraryValidationTest {
         try {
             ItineraryValidation.validateItinerariesOrder(testList1);
         } catch (DefaultException e) {
+            //where
             Assertions.assertEquals(DUPLICATE_ITINERARY_OEDER, e.getErrorCode());
         }
 
@@ -54,6 +54,7 @@ class ItineraryValidationTest {
         try {
             ItineraryValidation.validateItinerariesOrder(testList2);
         } catch (DefaultException e) {
+            //where
             Assertions.assertEquals(INCORRECT_ORDER, e.getErrorCode());
         }
     }

--- a/src/test/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryValidationTest.java
+++ b/src/test/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryValidationTest.java
@@ -1,7 +1,7 @@
 package com.fastcampus.toyproject.domain.itinerary.util;
 
 import com.fastcampus.toyproject.common.exception.DefaultException;
-import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryDTO;
+import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryRequestDTO;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,7 +16,7 @@ import static com.fastcampus.toyproject.common.exception.ExceptionCode.INCORRECT
 class ItineraryValidationTest {
 
     LocalDateTime testStartDate, testEndDate;
-    List<ItineraryDTO> testList1, testList2;
+    List<ItineraryRequestDTO> testList1, testList2;
 
     public ItineraryValidationTest() {
         this.testList1 = new ArrayList<>();
@@ -27,15 +27,15 @@ class ItineraryValidationTest {
 
     @BeforeEach
     void setUp() {
-        testList1.add(ItineraryDTO.builder().type(1).name("비행기").order(1).startDate(testStartDate).endDate(testEndDate).build());
-        testList1.add(ItineraryDTO.builder().type(2).name("호텔").order(2).startDate(testStartDate).endDate(testEndDate).build());
-        testList1.add(ItineraryDTO.builder().type(3).name("롯데월드").order(2).startDate(testStartDate).endDate(testEndDate).build());
-        testList1.add(ItineraryDTO.builder().type(2).name("호텔").order(3).startDate(testStartDate).endDate(testEndDate).build());
+        testList1.add(ItineraryRequestDTO.builder().type(1).name("비행기").order(1).startDate(testStartDate).endDate(testEndDate).build());
+        testList1.add(ItineraryRequestDTO.builder().type(2).name("호텔").order(2).startDate(testStartDate).endDate(testEndDate).build());
+        testList1.add(ItineraryRequestDTO.builder().type(3).name("롯데월드").order(2).startDate(testStartDate).endDate(testEndDate).build());
+        testList1.add(ItineraryRequestDTO.builder().type(2).name("호텔").order(3).startDate(testStartDate).endDate(testEndDate).build());
 
-        testList2.add(ItineraryDTO.builder().type(1).name("비행기").order(1).startDate(testStartDate).endDate(testEndDate).build());
-        testList2.add(ItineraryDTO.builder().type(2).name("호텔").order(10).startDate(testStartDate).endDate(testEndDate).build());
-        testList2.add(ItineraryDTO.builder().type(3).name("롯데월드").order(3).startDate(testStartDate).endDate(testEndDate).build());
-        testList2.add(ItineraryDTO.builder().type(2).name("호텔").order(4).startDate(testStartDate).endDate(testEndDate).build());
+        testList2.add(ItineraryRequestDTO.builder().type(1).name("비행기").order(1).startDate(testStartDate).endDate(testEndDate).build());
+        testList2.add(ItineraryRequestDTO.builder().type(2).name("호텔").order(10).startDate(testStartDate).endDate(testEndDate).build());
+        testList2.add(ItineraryRequestDTO.builder().type(3).name("롯데월드").order(3).startDate(testStartDate).endDate(testEndDate).build());
+        testList2.add(ItineraryRequestDTO.builder().type(2).name("호텔").order(4).startDate(testStartDate).endDate(testEndDate).build());
     }
 
     @Test

--- a/src/test/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryValidationTest.java
+++ b/src/test/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryValidationTest.java
@@ -1,0 +1,61 @@
+package com.fastcampus.toyproject.domain.itinerary.util;
+
+import com.fastcampus.toyproject.common.exception.DefaultException;
+import com.fastcampus.toyproject.common.exception.ExceptionCode;
+import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryDTO;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.fastcampus.toyproject.common.exception.ExceptionCode.DUPLICATE_ITINERARY_OEDER;
+import static com.fastcampus.toyproject.common.exception.ExceptionCode.INCORRECT_ORDER;
+
+class ItineraryValidationTest {
+
+    LocalDateTime testStartDate, testEndDate;
+    List<ItineraryDTO> testList1, testList2;
+
+    public ItineraryValidationTest() {
+        this.testList1 = new ArrayList<>();
+        this.testList2 = new ArrayList<>();
+        this.testStartDate = LocalDateTime.now();
+        this.testEndDate = LocalDateTime.now();
+    }
+
+    @BeforeEach
+    void setUp() {
+        testList1.add(ItineraryDTO.builder().type(1).name("비행기").order(1).startDate(testStartDate).endDate(testEndDate).build());
+        testList1.add(ItineraryDTO.builder().type(2).name("호텔").order(2).startDate(testStartDate).endDate(testEndDate).build());
+        testList1.add(ItineraryDTO.builder().type(3).name("롯데월드").order(2).startDate(testStartDate).endDate(testEndDate).build());
+        testList1.add(ItineraryDTO.builder().type(2).name("호텔").order(3).startDate(testStartDate).endDate(testEndDate).build());
+
+        testList2.add(ItineraryDTO.builder().type(1).name("비행기").order(1).startDate(testStartDate).endDate(testEndDate).build());
+        testList2.add(ItineraryDTO.builder().type(2).name("호텔").order(10).startDate(testStartDate).endDate(testEndDate).build());
+        testList2.add(ItineraryDTO.builder().type(3).name("롯데월드").order(3).startDate(testStartDate).endDate(testEndDate).build());
+        testList2.add(ItineraryDTO.builder().type(2).name("호텔").order(4).startDate(testStartDate).endDate(testEndDate).build());
+    }
+
+    @Test
+    public void 순서가_제대로_검증이_되는지_확인() {
+        //given
+
+        //when 1) 중복 순서 검사
+        try {
+            ItineraryValidation.validateItinerariesOrder(testList1);
+        } catch (DefaultException e) {
+            Assertions.assertEquals(DUPLICATE_ITINERARY_OEDER, e.getErrorCode());
+        }
+
+        //when 2) 여정 번호 순서대로인지 검사
+        try {
+            ItineraryValidation.validateItinerariesOrder(testList2);
+        } catch (DefaultException e) {
+            Assertions.assertEquals(INCORRECT_ORDER, e.getErrorCode());
+        }
+    }
+
+}


### PR DESCRIPTION
## 개요
여정 관련 클래스 (요청 DTO, 컨트롤러, 서비스, 레포지토리) 생성.
여정 순서 검증 메소드 (util - ItineraryValidation) 추가 - test 완료

## 변경로직

### 변경전

### 변경후

* 여정 RequestDTO 생성 
```
* 일단 이동, 체류, 숙박은 하나의 요청 DTO로 받습니다. 
* type에 따라 1은 이동, 2은 숙박, 3은 체류 로 분류하여 서비스 단에서 각각 맞는 entity로 변환할 예정입니다. 
* 그렇기 때문에 출발 장소와 도착 장소는 이동에서만 필요한 필드로써 @NotNull을 붙이지 않습니다. 
```

* 컨트롤러 requestMapping 추가 
![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/59862752/049554fc-83b8-41f4-84fd-9c69ed86d7cb)

* 서비스, 레포지토리 생성 
* 이동, 체류, 숙박 패키지 이동 

![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/59862752/73e1a5aa-7a8d-4bdd-8967-a8556df21872)



* 순서 검증 메소드 추가 
```
- 애초에 입력할 때부터 requestDTO 에서 min(1)로 두어 0이하의 숫자는 입력이 불가능합니다. 
- 먼저 순서가 중복되는 번호가 있는지 검사
- 순서가 순서대로 1부터 있는지 검사 
- 테스트 완료 했습니다. 
```

## 사용방법
- 테스트 참고 

## 기타

* type(이동, 체류, 숙박) 에 따른 enum 만들고 싶은데.. 방법을 잘 모르겠습니다. 
* 여정 같은 경우는 담당이 2명이라 PR을 자주 날려야 할 것 같습니다..!
* 메소드 이름, 클래스 이름, 필드 이름 피드백 환영합니다





