### PR TITLE
[refactor] JPAConfig.java 파일 위치 이동

### DIFF
--- a/src/main/java/com/fastcampus/toyproject/config/jpa/JPAConfig.java
+++ b/src/main/java/com/fastcampus/toyproject/config/jpa/JPAConfig.java
@@ -1,4 +1,4 @@
-package com.fastcampus.toyproject.common.config;
+package com.fastcampus.toyproject.config.jpa;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;


### PR DESCRIPTION
## 개요
JPAConfig의 위치를 config.jpa로 옮겼습니다.
## 작업사항
common 패키지는 일반적으로 같이 사용하는 클래스들의 모임이라고 생각합니다.
spring 관련 config 파일들은 config 패키지에 넣는게 더 명확할 거 같아 
JPAConfig 파일을 common.config 에서 config.jpa 로 이동했습니다.
### 변경전
### 변경후
![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/40512982/d415b3f3-1f8c-4282-a593-81f4004a56bc)
## 사용방법
## 기타
