### PR TITLE
[refactor] 엔티티들의 컬럼과 관계를 명확히 정의

### DIFF
--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Itinerary.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Itinerary.java
@@ -2,19 +2,21 @@ package com.fastcampus.toyproject.domain.itinerary.entity;
 
 import com.fastcampus.toyproject.domain.trip.entity.Trip;
 import java.time.LocalDateTime;
+import javax.persistence.Column;
 import javax.persistence.DiscriminatorColumn;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -29,17 +31,26 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public abstract class Itinerary {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     @JoinColumn(name = "tripId")
     private Trip tripId;
+
+    @Column(nullable = false)
     private String itineraryName;
+
+    @Column(nullable = false)
     private Integer itineraryOrder;
+
+    @ColumnDefault("false")
     private Boolean isDeleted;
+
     private LocalDateTime deletedAt;
+
     @CreatedDate
     private LocalDateTime createdAt;
+
     @LastModifiedDate
     private LocalDateTime updatedAt;
 

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Itinerary.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Itinerary.java
@@ -32,9 +32,10 @@ public abstract class Itinerary {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Long itineraryId;
+
     @ManyToOne
-    @JoinColumn(name = "id")
+    @JoinColumn(name = "tripId")
     private Trip tripId;
 
     @Column(nullable = false)

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Itinerary.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Itinerary.java
@@ -26,7 +26,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @NoArgsConstructor
 @AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
-@Inheritance(strategy = InheritanceType.TABLE_PER_CLASS)
+@Inheritance(strategy = InheritanceType.JOINED)
 @DiscriminatorColumn
 public abstract class Itinerary {
 

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Itinerary.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Itinerary.java
@@ -34,7 +34,7 @@ public abstract class Itinerary {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
-    @JoinColumn(name = "tripId")
+    @JoinColumn(name = "id")
     private Trip tripId;
 
     @Column(nullable = false)

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Itinerary.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Itinerary.java
@@ -6,6 +6,7 @@ import javax.persistence.Column;
 import javax.persistence.DiscriminatorColumn;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -34,7 +35,7 @@ public abstract class Itinerary {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long itineraryId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "tripId")
     private Trip tripId;
 

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Lodgement.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Lodgement.java
@@ -1,6 +1,5 @@
 package com.fastcampus.toyproject.domain.itinerary.entity;
 
-import com.fastcampus.toyproject.domain.itinerary.entity.Itinerary;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -28,10 +27,6 @@ public class Lodgement extends Itinerary {
 
     @Column(nullable = false)
     private LocalDateTime checkOut;
-
-
-
-
 
 
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Lodgement.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Lodgement.java
@@ -3,9 +3,6 @@ package com.fastcampus.toyproject.domain.itinerary.entity;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,10 +14,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class Lodgement extends Itinerary {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
 
     @Column(nullable = false)
     private LocalDateTime checkIn;

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Lodgement.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Lodgement.java
@@ -2,8 +2,10 @@ package com.fastcampus.toyproject.domain.itinerary.entity;
 
 import com.fastcampus.toyproject.domain.itinerary.entity.Itinerary;
 import java.time.LocalDateTime;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,9 +20,13 @@ import lombok.NoArgsConstructor;
 public class Lodgement extends Itinerary {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false)
     private LocalDateTime checkIn;
+
+    @Column(nullable = false)
     private LocalDateTime checkOut;
 
 

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Movement.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Movement.java
@@ -3,9 +3,6 @@ package com.fastcampus.toyproject.domain.itinerary.entity;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,11 +13,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Movement {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class Movement extends Itinerary {
 
     @Column(nullable = false)
     private LocalDateTime departureDate;

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Movement.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Movement.java
@@ -1,7 +1,10 @@
 package com.fastcampus.toyproject.domain.itinerary.entity;
 
 import java.time.LocalDateTime;
+import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,9 +19,18 @@ import lombok.NoArgsConstructor;
 public class Movement {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false)
     private LocalDateTime departureDate;
+
+    @Column(nullable = false)
     private LocalDateTime arrivalDate;
+
+    @Column(nullable = false)
     private String departurePlace;
+
+    @Column(nullable = false)
     private String arrivalPlace;
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Stay.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Stay.java
@@ -1,7 +1,10 @@
 package com.fastcampus.toyproject.domain.itinerary.entity;
 
 import java.time.LocalDateTime;
+import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,8 +19,13 @@ import lombok.NoArgsConstructor;
 public class Stay {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false)
     private LocalDateTime departureDate;
+
+    @Column(nullable = false)
     private LocalDateTime arrivalDate;
 
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Stay.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Stay.java
@@ -3,9 +3,6 @@ package com.fastcampus.toyproject.domain.itinerary.entity;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,11 +13,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Stay {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class Stay extends Itinerary {
 
     @Column(nullable = false)
     private LocalDateTime departureDate;

--- a/src/main/java/com/fastcampus/toyproject/domain/member/entity/Member.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/member/entity/Member.java
@@ -19,7 +19,7 @@ public class Member {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Long memberId;
 
     @Column(nullable = false)
     private String nickName;

--- a/src/main/java/com/fastcampus/toyproject/domain/member/entity/Member.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/member/entity/Member.java
@@ -1,6 +1,9 @@
 package com.fastcampus.toyproject.domain.member.entity;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,7 +18,10 @@ import lombok.NoArgsConstructor;
 public class Member {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false)
     private String nickName;
 
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/entity/Trip.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/entity/Trip.java
@@ -27,10 +27,10 @@ public class Trip {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Long tripId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "id")
+    @JoinColumn(name = "memberId")
     private Member memberId;
 
     @Column(nullable = false)

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/entity/Trip.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/entity/Trip.java
@@ -30,7 +30,7 @@ public class Trip {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "memberId")
+    @JoinColumn(name = "id")
     private Member memberId;
 
     @Column(nullable = false)

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/entity/Trip.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/entity/Trip.java
@@ -2,15 +2,19 @@ package com.fastcampus.toyproject.domain.trip.entity;
 
 import com.fastcampus.toyproject.domain.member.entity.Member;
 import java.time.LocalDateTime;
+import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
@@ -22,19 +26,33 @@ import org.springframework.data.annotation.LastModifiedDate;
 public class Trip {
 
     @Id
-    @GeneratedValue
-    private Long tripId;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "memberId")
     private Member memberId;
+
+    @Column(nullable = false)
     private String tripName;
+
+    @Column(nullable = false)
     private LocalDateTime startDate;
+
+    @Column(nullable = false)
     private LocalDateTime endDate;
+
+    @ColumnDefault("true")
     private boolean isDomestic;
+
+    @ColumnDefault("false")
     private boolean isDeleted;
+
     private LocalDateTime deletedAt;
+
     @CreatedDate
     private LocalDateTime createdAt;
+
     @LastModifiedDate
     private LocalDateTime updatedAt;
 


### PR DESCRIPTION
## 개요
각 엔티티들의 컬럼과 관계를 명확하게 정의
## 작업사항
각컬럼에 nullable 여부를 설정, Join 테이블에 대한 Id명시, LazyType 설정,
여정의 서브타입 클래스들은 여정Id가 fk이기 때문에 Id를 삭제 함.
## 변경로직
### 변경전
### 변경후

서브타입 클래스의 ID제거
![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/40512982/2a7c36b5-d14d-41fc-852b-563774b01ae7)

각 컬럼 상세정보 명시
![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/40512982/a2c9023a-e475-4695-a563-0b3137e725e9)

## 사용방법
## 기타
엔티티와 DB에 테이블 생성까지 확인했습니다.
실제 사용시에 문제가 발생할 수도 있을거 같아요. 실 사용시에 문제가 생기면 말씀해 주시면 감사하겠습니다.
