### PR TITLE
[refactor] 상속관계 엔티티를 superBuilder로 수정

### DIFF
--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Itinerary.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Itinerary.java
@@ -17,6 +17,7 @@ import javax.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -29,6 +30,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 @Inheritance(strategy = InheritanceType.JOINED)
 @DiscriminatorColumn
+@SuperBuilder
 public abstract class Itinerary {
 
     @Id

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Lodgement.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Lodgement.java
@@ -4,15 +4,15 @@ import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+@SuperBuilder
 public class Lodgement extends Itinerary {
 
     @Column(nullable = false)

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Movement.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Movement.java
@@ -4,15 +4,16 @@ import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
 
 @Entity
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+@SuperBuilder
 public class Movement extends Itinerary {
 
     @Column(nullable = false)

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Stay.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Stay.java
@@ -4,15 +4,15 @@ import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+@SuperBuilder
 public class Stay extends Itinerary {
 
     @Column(nullable = false)


### PR DESCRIPTION
## 개요
상속관계의 엔티티의 빌더를 @SuperBuilder로 수정했습니다.
## 작업사항
상속관계에선 빌더를 @SuperBuilder를 써야하는걸 깜빡했네요
## 변경로직
### 변경전
### 변경후
![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/40512982/a86a4652-d45f-4195-9004-007ca8c274f4)
![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/40512982/5162c220-4590-425e-bbce-fce83e733762)

## 사용방법
## 기타
