### PR TITLE
[Feat] 여행 정보를 등록, 수정, 삭제한다.

### DIFF
--- a/src/main/java/com/fastcampus/toyproject/common/dto/ErrorResponseDTO.java
+++ b/src/main/java/com/fastcampus/toyproject/common/dto/ErrorResponseDTO.java
@@ -20,9 +20,8 @@ public class ErrorResponseDTO {
     }
 
 
-    /*
-    에러 발생시 사용 예시
-    ResponseEntity<ErrorResponse>
-    return new ResponseEntity<ErrorResponse.error(코드, 메시지)>;
-     */
+    // 사용자 지정 메시지를 위한 오버로드된 메서드 추가
+    public static ErrorResponseDTO error(String errorMsg) {
+        return new ErrorResponseDTO(INTERNAL_SERVER_ERROR, errorMsg);
+    }
 }

--- a/src/main/java/com/fastcampus/toyproject/common/dto/ErrorResponseDTO.java
+++ b/src/main/java/com/fastcampus/toyproject/common/dto/ErrorResponseDTO.java
@@ -5,9 +5,11 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import static com.fastcampus.toyproject.common.exception.ExceptionCode.INTERNAL_SERVER_ERROR;
+
 @Getter
 @RequiredArgsConstructor
 public class ErrorResponseDTO {
+
     private final ExceptionCode exceptionCode;
     private final String errorMsg;
 
@@ -20,8 +22,4 @@ public class ErrorResponseDTO {
     }
 
 
-    // 사용자 지정 메시지를 위한 오버로드된 메서드 추가
-    public static ErrorResponseDTO error(String errorMsg) {
-        return new ErrorResponseDTO(INTERNAL_SERVER_ERROR, errorMsg);
-    }
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/controller/TripController.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/controller/TripController.java
@@ -1,9 +1,64 @@
 package com.fastcampus.toyproject.domain.trip.controller;
 
-
-import org.springframework.web.bind.annotation.RestController;
+import com.fastcampus.toyproject.common.dto.ErrorResponseDTO;
+import com.fastcampus.toyproject.common.dto.ResponseDTO;
+import com.fastcampus.toyproject.domain.trip.dto.TripDTO;
+import com.fastcampus.toyproject.domain.trip.entity.Trip;
+import com.fastcampus.toyproject.domain.trip.service.TripService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
+@RequestMapping("/api/trip")
 public class TripController {
+    private static final Logger log = LoggerFactory.getLogger(TripController.class);
+
+
+    @Autowired
+    private TripService tripService;
+
+    @PostMapping
+    public ResponseEntity<?> insertTrip(@RequestBody TripDTO tripDTO) {
+        System.out.println(tripDTO);
+
+        try {
+            Trip savedTrip = tripService.insertTrip(tripDTO);
+            return ResponseEntity.ok(ResponseDTO.ok("Trip이 성공적으로 저장되었습니다.", savedTrip));
+        } catch (Exception e) {
+            return new ResponseEntity<>(ErrorResponseDTO.error(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<?> updateTrip(@PathVariable Long id, @RequestBody TripDTO tripDTO) {
+        try {
+            Trip updatedTrip = tripService.updateTrip(id, tripDTO);
+            if (updatedTrip == null) {
+                return new ResponseEntity<>(ErrorResponseDTO.error(), HttpStatus.NOT_FOUND);
+            }
+            return ResponseEntity.ok(ResponseDTO.ok("Trip이 성공적으로 업데이트되었습니다.", updatedTrip));
+        } catch (Exception e) {
+            log.error("Error updating trip", e);
+            return new ResponseEntity<>(ErrorResponseDTO.error(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @DeleteMapping("/{id}")  // DELETE 요청을 처리하는 메서드
+    public ResponseEntity<?> deleteTrip(@PathVariable Long id) {
+        try {
+            boolean isDeleted = tripService.deleteTrip(id);
+            if (!isDeleted) {
+                return new ResponseEntity<>(ErrorResponseDTO.error("해당하는 Trip이 없습니다."), HttpStatus.NOT_FOUND);
+            }
+            return ResponseEntity.ok(ResponseDTO.ok("Trip이 성공적으로 삭제되었습니다."));
+        } catch (Exception e) {  // 예외 발생 시
+            return new ResponseEntity<>(ErrorResponseDTO.error(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
 
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/controller/TripController.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/controller/TripController.java
@@ -1,6 +1,6 @@
 package com.fastcampus.toyproject.domain.trip.controller;
 
-import com.fastcampus.toyproject.common.dto.ErrorResponseDTO;
+
 import com.fastcampus.toyproject.common.dto.ResponseDTO;
 import com.fastcampus.toyproject.domain.trip.dto.TripDTO;
 import com.fastcampus.toyproject.domain.trip.entity.Trip;
@@ -8,57 +8,35 @@ import com.fastcampus.toyproject.domain.trip.service.TripService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/trip")
 public class TripController {
-    private static final Logger log = LoggerFactory.getLogger(TripController.class);
 
+    private static final Logger log = LoggerFactory.getLogger(TripController.class);
 
     @Autowired
     private TripService tripService;
 
     @PostMapping
-    public ResponseEntity<?> insertTrip(@RequestBody TripDTO tripDTO) {
-        System.out.println(tripDTO);
-
-        try {
-            Trip savedTrip = tripService.insertTrip(tripDTO);
-            return ResponseEntity.ok(ResponseDTO.ok("Trip이 성공적으로 저장되었습니다.", savedTrip));
-        } catch (Exception e) {
-            return new ResponseEntity<>(ErrorResponseDTO.error(), HttpStatus.INTERNAL_SERVER_ERROR);
-        }
-
+    public ResponseEntity<ResponseDTO<Trip>> insertTrip(@RequestBody TripDTO tripDTO) {
+        Trip savedTrip = tripService.insertTrip(tripDTO);
+        return ResponseEntity.ok(ResponseDTO.ok("Trip이 성공적으로 저장되었습니다.", savedTrip));
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<?> updateTrip(@PathVariable Long id, @RequestBody TripDTO tripDTO) {
-        try {
-            Trip updatedTrip = tripService.updateTrip(id, tripDTO);
-            if (updatedTrip == null) {
-                return new ResponseEntity<>(ErrorResponseDTO.error(), HttpStatus.NOT_FOUND);
-            }
-            return ResponseEntity.ok(ResponseDTO.ok("Trip이 성공적으로 업데이트되었습니다.", updatedTrip));
-        } catch (Exception e) {
-            log.error("Error updating trip", e);
-            return new ResponseEntity<>(ErrorResponseDTO.error(), HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+    public ResponseEntity<ResponseDTO<Trip>> updateTrip(@PathVariable Long id,
+        @RequestBody TripDTO tripDTO) {
+        Trip updatedTrip = tripService.updateTrip(id, tripDTO);
+        return ResponseEntity.ok(ResponseDTO.ok("Trip이 성공적으로 업데이트되었습니다.", updatedTrip));
     }
 
-    @DeleteMapping("/{id}")  // DELETE 요청을 처리하는 메서드
-    public ResponseEntity<?> deleteTrip(@PathVariable Long id) {
-        try {
-            boolean isDeleted = tripService.deleteTrip(id);
-            if (!isDeleted) {
-                return new ResponseEntity<>(ErrorResponseDTO.error("해당하는 Trip이 없습니다."), HttpStatus.NOT_FOUND);
-            }
-            return ResponseEntity.ok(ResponseDTO.ok("Trip이 성공적으로 삭제되었습니다."));
-        } catch (Exception e) {  // 예외 발생 시
-            return new ResponseEntity<>(ErrorResponseDTO.error(), HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ResponseDTO<Void>> deleteTrip(@PathVariable Long id) {
+        tripService.deleteTrip(id);
+        return ResponseEntity.ok(ResponseDTO.ok("Trip이 성공적으로 삭제되었습니다."));
     }
-
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/dto/TripDTO.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/dto/TripDTO.java
@@ -1,0 +1,18 @@
+// TripDTO
+package com.fastcampus.toyproject.domain.trip.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import java.time.LocalDateTime;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class TripDTO {
+    private Long memberId;
+    private String tripName;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    private boolean isDomestic;
+}

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/dto/TripDTO.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/dto/TripDTO.java
@@ -10,9 +10,12 @@ import lombok.ToString;
 @Setter
 @ToString
 public class TripDTO {
+
     private Long memberId;
     private String tripName;
     private LocalDateTime startDate;
     private LocalDateTime endDate;
     private boolean isDomestic;
+
+
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/entity/Trip.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/entity/Trip.java
@@ -4,6 +4,7 @@ import com.fastcampus.toyproject.domain.member.entity.Member;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -14,12 +15,16 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -51,9 +56,16 @@ public class Trip {
     private LocalDateTime deletedAt;
 
     @CreatedDate
+    @Column(updatable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate
     private LocalDateTime updatedAt;
+
+    public void setIsDeleted(boolean isDeleted) {
+        this.isDeleted = isDeleted;
+    }
+
+
 
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/entity/Trip.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/entity/Trip.java
@@ -1,21 +1,27 @@
 package com.fastcampus.toyproject.domain.trip.entity;
 
+
 import com.fastcampus.toyproject.domain.member.entity.Member;
 import java.time.LocalDateTime;
+import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EntityListeners;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -30,12 +36,20 @@ public class Trip {
     private String tripName;
     private LocalDateTime startDate;
     private LocalDateTime endDate;
+
+
     private boolean isDomestic;
+
     private boolean isDeleted;
     private LocalDateTime deletedAt;
     @CreatedDate
+    @Column(updatable = false)
     private LocalDateTime createdAt;
     @LastModifiedDate
     private LocalDateTime updatedAt;
+
+    public void setIsDeleted(boolean isDeleted) {
+        this.isDeleted = isDeleted;
+    }
 
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/repository/TripRepository.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/repository/TripRepository.java
@@ -1,0 +1,7 @@
+package com.fastcampus.toyproject.domain.trip.repository;
+
+import com.fastcampus.toyproject.domain.trip.entity.Trip;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TripRepository extends JpaRepository<Trip, Long> {
+}

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/service/TripService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/service/TripService.java
@@ -1,5 +1,7 @@
 package com.fastcampus.toyproject.domain.trip.service;
 
+import com.fastcampus.toyproject.common.exception.DefaultException;
+import com.fastcampus.toyproject.common.exception.ExceptionCode;
 import com.fastcampus.toyproject.domain.trip.dto.TripDTO;
 import com.fastcampus.toyproject.domain.trip.entity.Trip;
 import com.fastcampus.toyproject.domain.trip.repository.TripRepository;
@@ -9,21 +11,14 @@ import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 
-@Service  // 서비스 클래스임을 나타냅니다.
+@Service
 public class TripService {
 
-    @Autowired  // 리포지토리를 자동으로 주입받습니다.
+    @Autowired
     private TripRepository tripRepository;
 
-
-
-    // Trip 정보를 저장하는 메서드
     public Trip insertTrip(TripDTO tripDTO) {
-        System.out.println("isDomestic value from DTO: " + tripDTO.isDomestic());
-
-
         Trip trip = Trip.builder()
-
             .tripName(tripDTO.getTripName())
             .startDate(tripDTO.getStartDate())
             .endDate(tripDTO.getEndDate())
@@ -33,33 +28,30 @@ public class TripService {
         return tripRepository.save(trip);
     }
 
-    // Trip 정보를 업데이트하는 메서드
     public Trip updateTrip(Long id, TripDTO tripDTO) {
         Optional<Trip> oldTrip = tripRepository.findById(id);
-        if (oldTrip.isPresent()) {
-            Trip existTrip = oldTrip.get();
-            existTrip.setTripName(tripDTO.getTripName());
-            existTrip.setStartDate(tripDTO.getStartDate());
-            existTrip.setEndDate(tripDTO.getEndDate());
-            existTrip.setDomestic(tripDTO.isDomestic());
-
-            return tripRepository.save(existTrip);
+        if (!oldTrip.isPresent()) {
+            throw new DefaultException(ExceptionCode.INVALID_REQUEST, "해당하는 Trip이 없습니다.");
         }
-        return null;
+
+        Trip existTrip = oldTrip.get();
+        existTrip.setTripName(tripDTO.getTripName());
+        existTrip.setStartDate(tripDTO.getStartDate());
+        existTrip.setEndDate(tripDTO.getEndDate());
+        existTrip.setDomestic(tripDTO.isDomestic());
+
+        return tripRepository.save(existTrip);
     }
 
-
-    // Trip 정보를 삭제하는 메서드
-    public boolean deleteTrip(Long id) {
+    public void deleteTrip(Long id) {
         Optional<Trip> tripOptional = tripRepository.findById(id);
-        if(tripOptional.isPresent()){
-            Trip trip = tripOptional.get();
-            trip.setIsDeleted(true);
-            trip.setDeletedAt(LocalDateTime.now());
-            tripRepository.save(trip);
-            return true;
+        if (!tripOptional.isPresent()) {
+            throw new DefaultException(ExceptionCode.INVALID_REQUEST, "해당하는 Trip이 없습니다.");
         }
-        return false;
-    }
 
+        Trip trip = tripOptional.get();
+        trip.setIsDeleted(true);
+        trip.setDeletedAt(LocalDateTime.now());
+        tripRepository.save(trip);
+    }
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/service/TripService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/service/TripService.java
@@ -1,0 +1,65 @@
+package com.fastcampus.toyproject.domain.trip.service;
+
+import com.fastcampus.toyproject.domain.trip.dto.TripDTO;
+import com.fastcampus.toyproject.domain.trip.entity.Trip;
+import com.fastcampus.toyproject.domain.trip.repository.TripRepository;
+import java.time.LocalDateTime;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service  // 서비스 클래스임을 나타냅니다.
+public class TripService {
+
+    @Autowired  // 리포지토리를 자동으로 주입받습니다.
+    private TripRepository tripRepository;
+
+
+
+    // Trip 정보를 저장하는 메서드
+    public Trip insertTrip(TripDTO tripDTO) {
+        System.out.println("isDomestic value from DTO: " + tripDTO.isDomestic());
+
+
+        Trip trip = Trip.builder()
+
+            .tripName(tripDTO.getTripName())
+            .startDate(tripDTO.getStartDate())
+            .endDate(tripDTO.getEndDate())
+            .isDomestic(tripDTO.isDomestic())
+            .build();
+
+        return tripRepository.save(trip);
+    }
+
+    // Trip 정보를 업데이트하는 메서드
+    public Trip updateTrip(Long id, TripDTO tripDTO) {
+        Optional<Trip> oldTrip = tripRepository.findById(id);
+        if (oldTrip.isPresent()) {
+            Trip existTrip = oldTrip.get();
+            existTrip.setTripName(tripDTO.getTripName());
+            existTrip.setStartDate(tripDTO.getStartDate());
+            existTrip.setEndDate(tripDTO.getEndDate());
+            existTrip.setDomestic(tripDTO.isDomestic());
+
+            return tripRepository.save(existTrip);
+        }
+        return null;
+    }
+
+
+    // Trip 정보를 삭제하는 메서드
+    public boolean deleteTrip(Long id) {
+        Optional<Trip> tripOptional = tripRepository.findById(id);
+        if(tripOptional.isPresent()){
+            Trip trip = tripOptional.get();
+            trip.setIsDeleted(true);
+            trip.setDeletedAt(LocalDateTime.now());
+            tripRepository.save(trip);
+            return true;
+        }
+        return false;
+    }
+
+}


### PR DESCRIPTION
## [Feat] 여행 정보를 등록, 수정, 삭제한다.

여행 정보를 등록, 수정, 삭제하는 로직을 구현했습니다.

- 여행 등록시 createdAt, updatedAt 갱신 / 입력한 데이터 저장
- 여행 수정시 updatedAt 갱신 / 수정된 데이터 저장
- 여행 삭제시 updatedAt, deletedAt 갱신, is_deleted 값 true로 변경

-------
- member 도메인이 구현이 안되어서 memberid값을 null로 받고 있습니다.
**isDomestic 값을 true로 보내도 계속 false로 반환이 되는데, 원인을 모르겠습니다... 혹시 아시는 분은 코드 리뷰로 남겨주세요..**

<img width="418" alt="image" src="https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/105612931/f79f3c96-18c0-46ca-aa56-f1f1e62fec8f">
