### PR TITLE
[Feat] 여정들 삽입 부분 1차 완성했습니다.  (멤버 로직 추가) (테스트 완)

### DIFF
--- a/src/main/java/com/fastcampus/toyproject/common/exception/ExceptionCode.java
+++ b/src/main/java/com/fastcampus/toyproject/common/exception/ExceptionCode.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 public enum ExceptionCode {
     NO_ITINERARY("해당되는 여정이 없습니다."),
-    DUPLICATE_ITINERARY_OEDER("여정 순서가 중복됩니다."),
+    DUPLICATE_ITINERARY_ORDER("여정 순서가 중복됩니다."),
     INCORRECT_ORDER("잘못된 여정 순서입니다."),
     INTERNAL_SERVER_ERROR("서버에 오류가 발생했습니다."),
     INVALID_REQUEST("잘못된 요청입니다.")

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/controller/ItineraryController.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/controller/ItineraryController.java
@@ -1,14 +1,27 @@
 package com.fastcampus.toyproject.domain.itinerary.controller;
 
+import com.fastcampus.toyproject.common.dto.ResponseDTO;
+import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryRequest;
+import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryResponse;
 import com.fastcampus.toyproject.domain.itinerary.service.ItineraryService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/itineraries")
 public class ItineraryController {
     private final ItineraryService itineraryService;
+
+    @PostMapping("/{tripId}")
+    public ResponseDTO<List<ItineraryResponse>> insertItineraries(
+            @PathVariable final Long tripId,
+            @Valid @RequestBody final List<ItineraryRequest> reqeust
+    ) {
+        return ResponseDTO.ok("여정들 삽입 완료", itineraryService.insertItineraries(tripId, reqeust));
+    }
 
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryRequest.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryRequest.java
@@ -1,26 +1,21 @@
 package com.fastcampus.toyproject.domain.itinerary.dto;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.annotation.JsonNaming;
-
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
 import lombok.*;
+import org.hibernate.validator.constraints.Range;
 
 import java.time.LocalDateTime;
 
 @Getter
-@Setter
 @ToString
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class ItineraryRequestDTO {
+public class ItineraryRequest {
 
     @NotNull
-    @Size(min = 1, max = 3)
+    @Range(min = 1, max = 3)
     private Integer type;
 
     @NotNull

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryResponse.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryResponse.java
@@ -1,0 +1,24 @@
+package com.fastcampus.toyproject.domain.itinerary.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ItineraryResponse {
+
+    private String itineraryName;
+    private Integer itineraryOrder;
+    private String itineraryType;
+
+}

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/LodgementResponse.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/LodgementResponse.java
@@ -1,0 +1,29 @@
+package com.fastcampus.toyproject.domain.itinerary.dto;
+
+import com.fastcampus.toyproject.domain.itinerary.entity.Lodgement;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+@Getter
+@ToString
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+public class LodgementResponse extends ItineraryResponse{
+    private LocalDateTime checkIn;
+    private LocalDateTime checkOut;
+
+    public static LodgementResponse fromEntity(Lodgement entity) {
+        return LodgementResponse
+                .builder()
+                .itineraryName(entity.getItineraryName())
+                .itineraryOrder(entity.getItineraryOrder())
+                .itineraryType("Lodgement")
+                .checkIn(entity.getCheckIn())
+                .checkOut(entity.getCheckOut())
+                .build();
+    }
+}

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/MovementResponse.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/MovementResponse.java
@@ -1,0 +1,33 @@
+package com.fastcampus.toyproject.domain.itinerary.dto;
+
+import com.fastcampus.toyproject.domain.itinerary.entity.Movement;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+@Getter
+@ToString
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MovementResponse extends ItineraryResponse {
+    private LocalDateTime departureDate;
+    private LocalDateTime arrivalDate;
+    private String departurePlace;
+    private String arrivalPlace;
+
+    public static MovementResponse fromEntity(Movement entity) {
+        return MovementResponse
+                .builder()
+                .itineraryName(entity.getItineraryName())
+                .itineraryOrder(entity.getItineraryOrder())
+                .itineraryType("Movement")
+                .departureDate(entity.getDepartureDate())
+                .arrivalDate(entity.getArrivalDate())
+                .departurePlace(entity.getDeparturePlace())
+                .arrivalPlace(entity.getArrivalPlace())
+                .build();
+    }
+}

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/StayResponse.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/StayResponse.java
@@ -1,0 +1,29 @@
+package com.fastcampus.toyproject.domain.itinerary.dto;
+
+import com.fastcampus.toyproject.domain.itinerary.entity.Stay;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+public class StayResponse extends ItineraryResponse {
+    private LocalDateTime departureDate;
+    private LocalDateTime arrivalDate;
+
+    public static StayResponse fromEntity(Stay entity) {
+        return StayResponse
+                .builder()
+                .itineraryName(entity.getItineraryName())
+                .itineraryOrder(entity.getItineraryOrder())
+                .itineraryType("Stay")
+                .departureDate(entity.getDepartureDate())
+                .arrivalDate(entity.getArrivalDate())
+                .build();
+    }
+}

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/repository/ItineraryRepository.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/repository/ItineraryRepository.java
@@ -1,9 +1,14 @@
 package com.fastcampus.toyproject.domain.itinerary.repository;
 
 import com.fastcampus.toyproject.domain.itinerary.entity.Itinerary;
+import com.fastcampus.toyproject.domain.trip.entity.Trip;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface ItineraryRepository extends JpaRepository<Itinerary, Long> {
+    Optional<List<Itinerary>> findAllByTripId(Trip tripId);
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
@@ -25,21 +25,11 @@ public class ItineraryService {
     private final MovementRepository movementRepository;
     private final StayRepository stayRepository;
 
-    private final MemberRepository memberRepository;
-
-    @Transactional
-    public void test() {
-        // test 용 메소드 (멤버, 여행 일부러 삽입) -> 추후 삭제 예정
-        Member member = Member.builder().memberId(1L).nickName("김종훈").build();
-        memberRepository.save(member);
-    }
-
     @Transactional
     public List<ItineraryResponse> insertItineraries (
             Long tripId,
             List<ItineraryRequest> request
     ) {
-        //test();
 
         List<ItineraryResponse> itineraryResponses = new ArrayList<>();
 
@@ -49,7 +39,7 @@ public class ItineraryService {
         //1. 여정 테이블에서 모든 값 가져오기.
         List<Itinerary> itineraries = itineraryRepository
                 .findAllByTripId(getTrip(tripId))
-                .orElseGet(() -> new ArrayList<>());
+                .orElseGet(ArrayList::new);
 
         //2. 현 request 에서 entity로 변환하여 리스트에 추가.
         for (ItineraryRequest ir : request) {

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
@@ -118,7 +118,7 @@ public class ItineraryService {
     private Trip getTrip(Long tripId) {
         return tripRepository
                 .findById(tripId)
-                .orElseThrow(() -> new DefaultException(ExceptionCode.NO_TRIP)
+                .orElseThrow(() -> new RuntimeException()
                 );
     }
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
@@ -1,18 +1,124 @@
 package com.fastcampus.toyproject.domain.itinerary.service;
 
-import com.fastcampus.toyproject.domain.itinerary.repository.ItineraryRepository;
-import com.fastcampus.toyproject.domain.itinerary.repository.LodgementRepository;
-import com.fastcampus.toyproject.domain.itinerary.repository.MovementRepository;
-import com.fastcampus.toyproject.domain.itinerary.repository.StayRepository;
+import com.fastcampus.toyproject.common.exception.DefaultException;
+import com.fastcampus.toyproject.common.exception.ExceptionCode;
+import com.fastcampus.toyproject.domain.itinerary.dto.*;
+import com.fastcampus.toyproject.domain.itinerary.entity.*;
+import com.fastcampus.toyproject.domain.itinerary.repository.*;
+import com.fastcampus.toyproject.domain.itinerary.util.ItineraryValidation;
+import com.fastcampus.toyproject.domain.member.entity.Member;
+import com.fastcampus.toyproject.domain.member.repository.MemberRepository;
+import com.fastcampus.toyproject.domain.trip.entity.Trip;
+import com.fastcampus.toyproject.domain.trip.repository.TripRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
 public class ItineraryService {
+    private final TripRepository tripRepository;
     private final ItineraryRepository itineraryRepository;
     private final LodgementRepository lodgementRepository;
     private final MovementRepository movementRepository;
     private final StayRepository stayRepository;
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public void test() {
+        // test 용 메소드 (멤버, 여행 일부러 삽입) -> 추후 삭제 예정
+        Member member = Member.builder().memberId(1L).nickName("김종훈").build();
+        memberRepository.save(member);
+    }
+
+    @Transactional
+    public List<ItineraryResponse> insertItineraries (
+            Long tripId,
+            List<ItineraryRequest> request
+    ) {
+        //test();
+
+        List<ItineraryResponse> itineraryResponses = new ArrayList<>();
+
+        //0. tripid를 통한 trip 객체 찾기. (method : getTrip(tripId))
+        Trip trip = getTrip(tripId);
+
+        //1. 여정 테이블에서 모든 값 가져오기.
+        List<Itinerary> itineraries = itineraryRepository
+                .findAllByTripId(getTrip(tripId))
+                .orElseGet(() -> new ArrayList<>());
+
+        //2. 현 request 에서 entity로 변환하여 리스트에 추가.
+        for (ItineraryRequest ir : request) {
+            Itinerary itinerary = null;
+            ItineraryResponse itineraryResponse = null;
+
+            switch (ir.getType()) {
+                case 1:
+                    if (ir.getDeparturePlace() == null || ir.getArrivalPlace() == null) {
+                        throw new RuntimeException();
+                    }
+
+                    itinerary = Movement
+                            .builder()
+                            .tripId(trip)
+                            .itineraryName(ir.getName())
+                            .itineraryOrder(ir.getOrder())
+                            .departureDate(ir.getStartDate())
+                            .arrivalDate(ir.getEndDate())
+                            .departurePlace(ir.getDeparturePlace())
+                            .arrivalPlace(ir.getArrivalPlace())
+                            .build();
+                    movementRepository.save((Movement) itinerary);
+                    itineraryResponse = MovementResponse.fromEntity((Movement) itinerary);
+
+                    break;
+                case 2:
+                    itinerary = Lodgement
+                            .builder()
+                            .tripId(trip)
+                            .itineraryName(ir.getName())
+                            .itineraryOrder(ir.getOrder())
+                            .checkIn(ir.getStartDate())
+                            .checkOut(ir.getEndDate())
+                            .build();
+                    lodgementRepository.save((Lodgement) itinerary);
+                    itineraryResponse = LodgementResponse.fromEntity((Lodgement) itinerary);
+                    break;
+                case 3:
+                    itinerary = Stay
+                            .builder()
+                            .tripId(trip)
+                            .itineraryName(ir.getName())
+                            .itineraryOrder(ir.getOrder())
+                            .departureDate(ir.getStartDate())
+                            .arrivalDate(ir.getEndDate())
+                            .build();
+                    stayRepository.save((Stay) itinerary);
+                    itineraryResponse = StayResponse.fromEntity((Stay) itinerary);
+                    break;
+            }
+            itineraries.add(itinerary);
+            itineraryResponses.add(itineraryResponse);
+        }
+
+        //3. 검증
+        ItineraryValidation.validateItinerariesOrder(itineraries);
+
+        //4. response 리스트 정렬. (오더 순서대로)
+        Collections.sort(itineraryResponses, Comparator.comparingInt(ItineraryResponse::getItineraryOrder));
+
+        return itineraryResponses;
+
+    }
+
+    private Trip getTrip(Long tripId) {
+        return tripRepository
+                .findById(tripId)
+                .orElseThrow(() -> new DefaultException(ExceptionCode.NO_TRIP)
+                );
+    }
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
@@ -48,8 +48,12 @@ public class ItineraryService {
 
             switch (ir.getType()) {
                 case 1:
-                    if (ir.getDeparturePlace() == null || ir.getArrivalPlace() == null) {
-                        throw new RuntimeException();
+                    if (ir.getDeparturePlace() == null) {
+                        throw new RuntimeException("이동의 경우 출발지 입력 하셔야 합니다.");
+                    }
+
+                    if (ir.getArrivalPlace() == null) {
+                        throw new RuntimeException("이동의 경우 도착지 입력 하셔야 합니다.");
                     }
 
                     itinerary = Movement
@@ -64,7 +68,6 @@ public class ItineraryService {
                             .build();
                     movementRepository.save((Movement) itinerary);
                     itineraryResponse = MovementResponse.fromEntity((Movement) itinerary);
-
                     break;
                 case 2:
                     itinerary = Lodgement

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
@@ -111,7 +111,7 @@ public class ItineraryService {
     private Trip getTrip(Long tripId) {
         return tripRepository
                 .findById(tripId)
-                .orElseThrow(() -> new RuntimeException()
+                .orElseThrow(() -> new RuntimeException("해당되는 여행이 없습니다.")
                 );
     }
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryValidation.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryValidation.java
@@ -1,11 +1,11 @@
 package com.fastcampus.toyproject.domain.itinerary.util;
 
 import com.fastcampus.toyproject.common.exception.DefaultException;
-import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryRequestDTO;
+import com.fastcampus.toyproject.domain.itinerary.entity.Itinerary;
 
 import java.util.*;
 
-import static com.fastcampus.toyproject.common.exception.ExceptionCode.DUPLICATE_ITINERARY_OEDER;
+import static com.fastcampus.toyproject.common.exception.ExceptionCode.DUPLICATE_ITINERARY_ORDER;
 import static com.fastcampus.toyproject.common.exception.ExceptionCode.INCORRECT_ORDER;
 
 public class ItineraryValidation {
@@ -13,21 +13,21 @@ public class ItineraryValidation {
     /**
      * 여정 순서가 적절하게 입력되었는지 확인하는 메소드
      * @author : 지운
-     * @param : itineraryDTOList
+     * @param : itineraryList
      * @return
      */
-    public static void validateItinerariesOrder(List<ItineraryRequestDTO> itineraryRequestDTOList) {
+    public static void validateItinerariesOrder(List<Itinerary> itineraryList) {
         //1. 순서가 중복되는지 검사하고, 순서대로 정렬. (O(NlogN))
-        Collections.sort(itineraryRequestDTOList, (o1, o2) -> {
-           if (o1.getOrder() == o2.getOrder()) {
-               throw new DefaultException(DUPLICATE_ITINERARY_OEDER);
-           }
-           return o1.getOrder() - o2.getOrder();
+        Collections.sort(itineraryList, (o1, o2) -> {
+            if (o1.getItineraryOrder() == o2.getItineraryOrder()) {
+                throw new DefaultException(DUPLICATE_ITINERARY_ORDER);
+            }
+            return o1.getItineraryOrder()- o2.getItineraryOrder();
         });
 
         //2. 순서가 1부터 차례대로 들어갔는지 확인. (O(N))
-        for (int orderIdx = 1; orderIdx <= itineraryRequestDTOList.size(); orderIdx++) {
-            if (itineraryRequestDTOList.get(orderIdx - 1).getOrder() != orderIdx) {
+        for (int orderIdx = 1; orderIdx <= itineraryList.size(); orderIdx++) {
+            if (itineraryList.get(orderIdx - 1).getItineraryOrder() != orderIdx) {
                 throw new DefaultException(INCORRECT_ORDER);
             }
         }

--- a/src/main/java/com/fastcampus/toyproject/domain/member/controller/MemberController.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/member/controller/MemberController.java
@@ -1,0 +1,21 @@
+package com.fastcampus.toyproject.domain.member.controller;
+
+import com.fastcampus.toyproject.domain.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/member")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/")
+    public void insert() {
+        memberService.insertTestMember();
+    }
+
+}

--- a/src/main/java/com/fastcampus/toyproject/domain/member/service/MemberService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/member/service/MemberService.java
@@ -1,0 +1,18 @@
+package com.fastcampus.toyproject.domain.member.service;
+
+import com.fastcampus.toyproject.domain.member.entity.Member;
+import com.fastcampus.toyproject.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    public void insertTestMember() {
+        Member member = Member.builder().memberId(1L).nickName("김종훈").build();
+        memberRepository.save(member);
+    }
+
+}

--- a/src/test/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryResponseTest.java
+++ b/src/test/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryResponseTest.java
@@ -1,0 +1,34 @@
+package com.fastcampus.toyproject.domain.itinerary.dto;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+
+class ItineraryResponseTest {
+    LocalDateTime testDate = LocalDateTime.now();
+
+    @Test
+    void 여정_응답_리스트_생성_테스트() {
+        List<ItineraryResponse> list = new ArrayList<>();
+        ItineraryResponse ir1 = MovementResponse.builder()
+                .itineraryName("비행기").itineraryOrder(1).departureDate(testDate).arrivalDate(testDate)
+                .departurePlace("인천").arrivalPlace("도쿄").build();
+        ItineraryResponse ir2 = LodgementResponse.builder()
+                .itineraryName("롯데호텔").itineraryOrder(2).checkIn(testDate).checkOut(testDate)
+                .build();
+        ItineraryResponse ir3 = StayResponse.builder()
+                .itineraryName("비행기").itineraryOrder(3).departureDate(testDate).arrivalDate(testDate)
+                .build();
+
+        list.add(ir1);
+        list.add(ir2);
+        list.add(ir3);
+
+
+    }
+
+
+}

--- a/src/test/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryValidationTest.java
+++ b/src/test/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryValidationTest.java
@@ -1,7 +1,7 @@
 package com.fastcampus.toyproject.domain.itinerary.util;
 
 import com.fastcampus.toyproject.common.exception.DefaultException;
-import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryRequestDTO;
+import com.fastcampus.toyproject.domain.itinerary.entity.Itinerary;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,13 +10,13 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.fastcampus.toyproject.common.exception.ExceptionCode.DUPLICATE_ITINERARY_OEDER;
+import static com.fastcampus.toyproject.common.exception.ExceptionCode.DUPLICATE_ITINERARY_ORDER;
 import static com.fastcampus.toyproject.common.exception.ExceptionCode.INCORRECT_ORDER;
 
 class ItineraryValidationTest {
 
     LocalDateTime testStartDate, testEndDate;
-    List<ItineraryRequestDTO> testList1, testList2;
+    List<Itinerary> testList1, testList2;
 
     public ItineraryValidationTest() {
         this.testList1 = new ArrayList<>();
@@ -27,19 +27,19 @@ class ItineraryValidationTest {
 
     @BeforeEach
     void setUp() {
-        testList1.add(ItineraryRequestDTO.builder().type(1).name("비행기").order(1).startDate(testStartDate).endDate(testEndDate).build());
-        testList1.add(ItineraryRequestDTO.builder().type(2).name("호텔").order(2).startDate(testStartDate).endDate(testEndDate).build());
-        testList1.add(ItineraryRequestDTO.builder().type(3).name("롯데월드").order(2).startDate(testStartDate).endDate(testEndDate).build());
-        testList1.add(ItineraryRequestDTO.builder().type(2).name("호텔").order(3).startDate(testStartDate).endDate(testEndDate).build());
-
-        testList2.add(ItineraryRequestDTO.builder().type(1).name("비행기").order(1).startDate(testStartDate).endDate(testEndDate).build());
-        testList2.add(ItineraryRequestDTO.builder().type(2).name("호텔").order(10).startDate(testStartDate).endDate(testEndDate).build());
-        testList2.add(ItineraryRequestDTO.builder().type(3).name("롯데월드").order(3).startDate(testStartDate).endDate(testEndDate).build());
-        testList2.add(ItineraryRequestDTO.builder().type(2).name("호텔").order(4).startDate(testStartDate).endDate(testEndDate).build());
+//        testList1.add(Itinerary.builder().type(1).name("비행기").order(1).startDate(testStartDate).endDate(testEndDate).build());
+//        testList1.add(Itinerary.builder().type(2).name("호텔").order(2).startDate(testStartDate).endDate(testEndDate).build());
+//        testList1.add(ItineraryReqeust.builder().type(3).name("롯데월드").order(2).startDate(testStartDate).endDate(testEndDate).build());
+//        testList1.add(ItineraryReqeust.builder().type(2).name("호텔").order(3).startDate(testStartDate).endDate(testEndDate).build());
+//
+//        testList2.add(ItineraryReqeust.builder().type(1).name("비행기").order(1).startDate(testStartDate).endDate(testEndDate).build());
+//        testList2.add(ItineraryReqeust.builder().type(2).name("호텔").order(10).startDate(testStartDate).endDate(testEndDate).build());
+//        testList2.add(ItineraryReqeust.builder().type(3).name("롯데월드").order(3).startDate(testStartDate).endDate(testEndDate).build());
+//        testList2.add(ItineraryReqeust.builder().type(2).name("호텔").order(4).startDate(testStartDate).endDate(testEndDate).build());
     }
 
     @Test
-    public void 순서가_제대로_검증이_되는지_확인() {
+    void 순서가_제대로_검증이_되는지_확인() {
         //given
 
         //when 1) 중복 순서 검사
@@ -47,7 +47,7 @@ class ItineraryValidationTest {
             ItineraryValidation.validateItinerariesOrder(testList1);
         } catch (DefaultException e) {
             //where
-            Assertions.assertEquals(DUPLICATE_ITINERARY_OEDER, e.getErrorCode());
+            Assertions.assertEquals(DUPLICATE_ITINERARY_ORDER, e.getErrorCode());
         }
 
         //when 2) 여정 번호 순서대로인지 검사

--- a/src/test/java/com/fastcampus/toyproject/http_requests/itinerary-create.http
+++ b/src/test/java/com/fastcampus/toyproject/http_requests/itinerary-create.http
@@ -1,0 +1,29 @@
+POST http://localhost:8080/itineraries/1
+Content-Type: application/json
+
+[
+  {
+    "type" : 1,
+    "name" : "비행기",
+    "startDate" : "2023-10-25T17:03:10",
+    "endDate" : "2023-10-25T17:03:10",
+    "order" : 1,
+    "departurePlace" : "인천 공항",
+    "arrivalPlace" : "도쿄 공항"
+  },
+  {
+    "type" : 3,
+    "name" : "디즈니월드",
+    "startDate" : "2023-10-25T17:03:10",
+    "endDate" : "2023-10-25T17:03:10",
+    "order" : 2
+  },
+  {
+    "type" : 2,
+    "name" : "도쿄 호텔",
+    "startDate" : "2023-10-25T17:03:10",
+    "endDate" : "2023-10-25T17:03:10",
+    "order" : 3
+  }
+]
+

--- a/src/test/java/com/fastcampus/toyproject/http_requests/itnerary-create2.http
+++ b/src/test/java/com/fastcampus/toyproject/http_requests/itnerary-create2.http
@@ -1,0 +1,29 @@
+POST http://localhost:8080/itineraries/1
+Content-Type: application/json
+
+[
+  {
+    "type" : 1,
+    "name" : "버스",
+    "startDate" : "2023-10-25T17:03:10",
+    "endDate" : "2023-10-25T17:03:10",
+    "order" : 5,
+    "departurePlace" : "도쿄 타워",
+    "arrivalPlace" : "도쿄 디즈니랜드"
+  },
+  {
+    "type" : 3,
+    "name" : "도쿄 타워",
+    "startDate" : "2023-10-25T17:03:10",
+    "endDate" : "2023-10-25T17:03:10",
+    "order" : 4
+  },
+  {
+    "type" : 2,
+    "name" : "도쿄 온천있는 호텔",
+    "startDate" : "2023-10-25T17:03:10",
+    "endDate" : "2023-10-25T17:03:10",
+    "order" : 6
+  }
+]
+

--- a/src/test/java/com/fastcampus/toyproject/http_requests/member-create-test.http
+++ b/src/test/java/com/fastcampus/toyproject/http_requests/member-create-test.http
@@ -1,0 +1,2 @@
+POST http://localhost:8080/member/
+Content-Type: application/json

--- a/src/test/java/com/fastcampus/toyproject/http_requests/trip-create.http
+++ b/src/test/java/com/fastcampus/toyproject/http_requests/trip-create.http
@@ -1,0 +1,10 @@
+POST http://localhost:8080/api/trip/
+Content-Type: application/json
+
+{
+  "memberId" : 1,
+  "tripName" : "일본 여행",
+  "startDate" : "2023-10-25T17:03:10",
+  "endDate" : "2023-10-25T17:03:10",
+  "isDomestic" : true
+}


### PR DESCRIPTION
## 개요
여정 삽입 부분 1차 완성했습니다. (테스트 완료)
멤버 로직 추가했어요.

## 작업사항
1. 여정 컨트롤러 
2. 여정 서비스
3. 여정 응답, 요청 DTO
4. 멤버 컨트롤러, 서비스
5. 테스트 코드 

<img width="1069" alt="스크린샷 2023-10-25 오후 12 16 30" src="https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/59862752/e1d53504-06a0-4790-b700-22bd3a3efc42">

## 변경로직
### 변경전
### 변경후

### 여정 삽입 서비스 로직 
```cmd
1) 여행 id로 여행 불러옴
2) 이미 저장된 여정들 불러옴
3) 여정 요청 DTO -> 여정 entity 변환 (각각에 맞춰) 
4) (3) 저장
5) 검증
6) 여정 순서대로 정렬 
```

## 사용방법

### 📌 인텔리제이 얼티밋 쓰시는 분들 읽어주세요
![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/59862752/58321e04-297e-41d8-9093-537a0a496f60)

<img width="1036" alt="스크린샷 2023-10-25 오후 12 17 46" src="https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/59862752/6845a45e-3a72-47d6-814f-400e8000d484">

```cmd
이렇게 http-request 용 파일 여러개 추가했어요.
실행하시고
member-create-test
trip-create
itinerary-create
itinerary-create2
순으로 사용하시면 확인될거에요.
```


## 기타

1) 여정 타입 (이동, 숙박, 체류) 일단 switch 문으로 작성했습니다. 로직이 좀 지저분하지만, 아직은 방법을 생각해봐야할 것 같애서요. 추후 수정 예정입니다. 
2) 에러 부분 
- 이동 입력시 출발지, 도착지 없으면 에러 -> 일단 런타임 에러 처리
- 여행아이디 없으면 - 일단 런타임에러
- 여정 순서 올바르지 않으면? - 에러 처리 완
