### PR TITLE
[Refactor] memberId 추가 및 isDomestic 오류 해결 

### DIFF
--- a/src/main/java/com/fastcampus/toyproject/common/BaseTimeEntity.java
+++ b/src/main/java/com/fastcampus/toyproject/common/BaseTimeEntity.java
@@ -1,0 +1,34 @@
+package com.fastcampus.toyproject.common;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Column(insertable = false)
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @Column(insertable = false)
+    private LocalDateTime deletedAt;
+
+    protected void delete(LocalDateTime currentTime) {
+        if (deletedAt == null) {
+            deletedAt = currentTime;
+        }
+    }
+
+
+}

--- a/src/main/java/com/fastcampus/toyproject/common/exception/ExceptionCode.java
+++ b/src/main/java/com/fastcampus/toyproject/common/exception/ExceptionCode.java
@@ -10,7 +10,9 @@ public enum ExceptionCode {
     DUPLICATE_ITINERARY_OEDER("여정 순서가 중복됩니다."),
     INCORRECT_ORDER("잘못된 여정 순서입니다."),
     INTERNAL_SERVER_ERROR("서버에 오류가 발생했습니다."),
-    INVALID_REQUEST("잘못된 요청입니다.")
+    INVALID_REQUEST("잘못된 요청입니다."),
+    NO_SUCH_TRIP("해당하는 Trip이 없습니다."),
+
     ;
 
     private String msg;

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/controller/TripController.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/controller/TripController.java
@@ -5,34 +5,35 @@ import com.fastcampus.toyproject.common.dto.ResponseDTO;
 import com.fastcampus.toyproject.domain.trip.dto.TripDTO;
 import com.fastcampus.toyproject.domain.trip.entity.Trip;
 import com.fastcampus.toyproject.domain.trip.service.TripService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/trip")
+@RequestMapping("/api/trip/{memberId}")
 public class TripController {
 
-    private static final Logger log = LoggerFactory.getLogger(TripController.class);
 
     @Autowired
     private TripService tripService;
 
     @PostMapping
-    public ResponseEntity<ResponseDTO<Trip>> insertTrip(@RequestBody TripDTO tripDTO) {
-        Trip savedTrip = tripService.insertTrip(tripDTO);
+    public ResponseEntity<ResponseDTO<Trip>> insertTrip(@PathVariable Long memberId,
+        @RequestBody TripDTO tripDTO) {
+        Trip savedTrip = tripService.insertTrip(memberId, tripDTO);
         return ResponseEntity.ok(ResponseDTO.ok("Trip이 성공적으로 저장되었습니다.", savedTrip));
     }
 
-    @PutMapping("/{id}")
-    public ResponseEntity<ResponseDTO<Trip>> updateTrip(@PathVariable Long id,
+    @PutMapping("/{tripId}")
+    public ResponseEntity<ResponseDTO<Trip>> updateTrip(
+        @PathVariable Long memberId,
+        @PathVariable Long tripId,
         @RequestBody TripDTO tripDTO) {
-        Trip updatedTrip = tripService.updateTrip(id, tripDTO);
+        Trip updatedTrip = tripService.updateTrip(memberId, tripId, tripDTO);
         return ResponseEntity.ok(ResponseDTO.ok("Trip이 성공적으로 업데이트되었습니다.", updatedTrip));
     }
+
 
     @DeleteMapping("/{id}")
     public ResponseEntity<ResponseDTO<Void>> deleteTrip(@PathVariable Long id) {

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/dto/TripDTO.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/dto/TripDTO.java
@@ -1,21 +1,24 @@
-// TripDTO
 package com.fastcampus.toyproject.domain.trip.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 import java.time.LocalDateTime;
-import lombok.ToString;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
-@ToString
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class TripDTO {
 
     private Long memberId;
     private String tripName;
     private LocalDateTime startDate;
     private LocalDateTime endDate;
-    private boolean isDomestic;
+    private Boolean isDomestic;
+
+
 
 
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/entity/Trip.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/entity/Trip.java
@@ -1,6 +1,8 @@
 package com.fastcampus.toyproject.domain.trip.entity;
 
+import com.fastcampus.toyproject.common.BaseTimeEntity;
 import com.fastcampus.toyproject.domain.member.entity.Member;
+import com.fastcampus.toyproject.domain.trip.dto.TripDTO;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -15,20 +17,16 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.hibernate.annotations.ColumnDefault;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class Trip {
+public class Trip extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -36,7 +34,7 @@ public class Trip {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "memberId")
-    private Member memberId;
+    private Member member;
 
     @Column(nullable = false)
     private String tripName;
@@ -48,24 +46,27 @@ public class Trip {
     private LocalDateTime endDate;
 
     @ColumnDefault("true")
-    private boolean isDomestic;
+    private Boolean isDomestic;
 
     @ColumnDefault("false")
     private boolean isDeleted;
 
-    private LocalDateTime deletedAt;
-
-    @CreatedDate
-    @Column(updatable = false)
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    private LocalDateTime updatedAt;
 
     public void setIsDeleted(boolean isDeleted) {
         this.isDeleted = isDeleted;
     }
 
+    @Override
+    public void delete(LocalDateTime currentTime) {
+        super.delete(currentTime);
+    }
+
+    public void updateFromDTO(TripDTO tripDTO) {
+        this.tripName = tripDTO.getTripName();
+        this.startDate = tripDTO.getStartDate();
+        this.endDate = tripDTO.getEndDate();
+        this.isDomestic = tripDTO.getIsDomestic();
+    }
 
 
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/service/TripService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/service/TripService.java
@@ -2,6 +2,8 @@ package com.fastcampus.toyproject.domain.trip.service;
 
 import com.fastcampus.toyproject.common.exception.DefaultException;
 import com.fastcampus.toyproject.common.exception.ExceptionCode;
+import com.fastcampus.toyproject.domain.member.entity.Member;
+import com.fastcampus.toyproject.domain.member.repository.MemberRepository;
 import com.fastcampus.toyproject.domain.trip.dto.TripDTO;
 import com.fastcampus.toyproject.domain.trip.entity.Trip;
 import com.fastcampus.toyproject.domain.trip.repository.TripRepository;
@@ -17,41 +19,52 @@ public class TripService {
     @Autowired
     private TripRepository tripRepository;
 
-    public Trip insertTrip(TripDTO tripDTO) {
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member getValidatedMember(Long memberId) {
+        return memberRepository.findById(memberId)
+            .orElseThrow(
+                () -> new DefaultException(ExceptionCode.INVALID_REQUEST, "해당하는 멤버가 없습니다."));
+    }
+
+    public Trip insertTrip(Long memberId, TripDTO tripDTO) {
+        Member member = getValidatedMember(memberId);
+
         Trip trip = Trip.builder()
+            .member(member)
             .tripName(tripDTO.getTripName())
             .startDate(tripDTO.getStartDate())
             .endDate(tripDTO.getEndDate())
-            .isDomestic(tripDTO.isDomestic())
+            .isDomestic(tripDTO.getIsDomestic())
             .build();
 
         return tripRepository.save(trip);
     }
 
-    public Trip updateTrip(Long id, TripDTO tripDTO) {
-        Optional<Trip> oldTrip = tripRepository.findById(id);
-        if (!oldTrip.isPresent()) {
-            throw new DefaultException(ExceptionCode.INVALID_REQUEST, "해당하는 Trip이 없습니다.");
+    public Trip updateTrip(Long memberId, Long tripId, TripDTO tripDTO) {
+        Member member = getValidatedMember(memberId);
+
+        Trip existTrip = tripRepository.findById(tripId)
+            .orElseThrow(() -> new DefaultException(ExceptionCode.NO_SUCH_TRIP));
+
+        if (!existTrip.getMember().getMemberId().equals(memberId)) {
+            throw new DefaultException(ExceptionCode.INVALID_REQUEST, "멤버의 여행 정보가 일치하지 않습니다.");
         }
 
-        Trip existTrip = oldTrip.get();
-        existTrip.setTripName(tripDTO.getTripName());
-        existTrip.setStartDate(tripDTO.getStartDate());
-        existTrip.setEndDate(tripDTO.getEndDate());
-        existTrip.setDomestic(tripDTO.isDomestic());
-
+        existTrip.updateFromDTO(tripDTO);
         return tripRepository.save(existTrip);
     }
 
     public void deleteTrip(Long id) {
         Optional<Trip> tripOptional = tripRepository.findById(id);
         if (!tripOptional.isPresent()) {
-            throw new DefaultException(ExceptionCode.INVALID_REQUEST, "해당하는 Trip이 없습니다.");
+            throw new DefaultException(ExceptionCode.NO_SUCH_TRIP);
         }
 
         Trip trip = tripOptional.get();
         trip.setIsDeleted(true);
-        trip.setDeletedAt(LocalDateTime.now());
+        trip.delete(LocalDateTime.now());
         tripRepository.save(trip);
     }
 }


### PR DESCRIPTION
## [Refactor] memberId 추가 및 isDomestic 오류 해결 
- DTO와 엔터티의 Setter 삭제
- isDomestic 값 변경 안되는 오류 해결
- 중복되는 exception 관리를 위해 리팩토링 진행
- BaseTimeEntity 생성
- ---------
**BaseTimeEntity 생성**

- createdAt, deletedAt, updatedAt이 다른 테이블에도 사용되어 BaseTimeEntity로 분리했습니다.
- 엔터티에서 BaseTimeEntity를 상속받아 사용하시면 됩니다.