### PR TITLE
[Feat] 여정들 삭제 부분 구현했습니다. 

### DIFF
--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/controller/ItineraryController.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/controller/ItineraryController.java
@@ -19,9 +19,17 @@ public class ItineraryController {
     @PostMapping("/{tripId}")
     public ResponseDTO<List<ItineraryResponse>> insertItineraries(
             @PathVariable final Long tripId,
-            @Valid @RequestBody final List<ItineraryRequest> reqeust
+            @Valid @RequestBody final List<ItineraryRequest> request
     ) {
-        return ResponseDTO.ok("여정들 삽입 완료", itineraryService.insertItineraries(tripId, reqeust));
+        return ResponseDTO.ok("여정들 삽입 완료", itineraryService.insertItineraries(tripId, request));
+    }
+
+    @DeleteMapping("/{tripId}")
+    public ResponseDTO<List<ItineraryResponse>> deleteItineraries(
+            @PathVariable final Long tripId,
+            @Valid @RequestBody final List<Long> deleteIdList
+    ) {
+        return ResponseDTO.ok("여정들 삭제 완료", itineraryService.deleteItineraries(tripId, deleteIdList));
     }
 
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/controller/ItineraryController.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/controller/ItineraryController.java
@@ -24,7 +24,7 @@ public class ItineraryController {
         return ResponseDTO.ok("여정들 삽입 완료", itineraryService.insertItineraries(tripId, request));
     }
 
-    @DeleteMapping("/{tripId}")
+    @PutMapping("/delete/{tripId}")
     public ResponseDTO<List<ItineraryResponse>> deleteItineraries(
             @PathVariable final Long tripId,
             @Valid @RequestBody final List<Long> deleteIdList

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryResponse.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryResponse.java
@@ -1,5 +1,6 @@
 package com.fastcampus.toyproject.domain.itinerary.dto;
 
+import com.fastcampus.toyproject.domain.itinerary.entity.Itinerary;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
@@ -20,5 +21,13 @@ public class ItineraryResponse {
     private String itineraryName;
     private Integer itineraryOrder;
     private String itineraryType;
+
+    public static ItineraryResponse fromEntity(Itinerary itinerary) {
+        return ItineraryResponse.builder()
+                .itineraryName(itinerary.getItineraryName())
+                .itineraryOrder(itinerary.getItineraryOrder())
+                .build()
+                ;
+    }
 
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Itinerary.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Itinerary.java
@@ -1,5 +1,6 @@
 package com.fastcampus.toyproject.domain.itinerary.entity;
 
+import com.fastcampus.toyproject.common.BaseTimeEntity;
 import com.fastcampus.toyproject.domain.trip.entity.Trip;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
@@ -50,12 +51,29 @@ public abstract class Itinerary {
     @ColumnDefault("false")
     private Boolean isDeleted;
 
-    private LocalDateTime deletedAt;
-
     @CreatedDate
     private LocalDateTime createdAt;
 
+    @Column(insertable = false)
     @LastModifiedDate
     private LocalDateTime updatedAt;
+
+    @Column(insertable = false)
+    private LocalDateTime deletedAt;
+
+    public void delete(LocalDateTime currentTime) {
+        if (deletedAt == null) {
+            deletedAt = currentTime;
+        }
+    }
+
+    public void updateDeleted() {
+        this.isDeleted = true;
+    }
+
+    public void updateItineraryOrder(Integer newOrder) {
+        this.itineraryOrder = newOrder;
+    }
+
 
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/repository/ItineraryRepository.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/repository/ItineraryRepository.java
@@ -10,5 +10,6 @@ import java.util.Optional;
 
 @Repository
 public interface ItineraryRepository extends JpaRepository<Itinerary, Long> {
-    Optional<List<Itinerary>> findAllByTripId(Trip tripId);
+    Optional<List<Itinerary>> findAllByTripIdAndIsDeletedNull(Trip tripId);
+
 }

--- a/src/test/java/com/fastcampus/toyproject/http_requests/itinerary-delete.http
+++ b/src/test/java/com/fastcampus/toyproject/http_requests/itinerary-delete.http
@@ -1,0 +1,6 @@
+PUT http://localhost:8080/itineraries/delete/1
+Content-Type: application/json
+
+[
+  1,3,5
+]


### PR DESCRIPTION
## 개요
- 여정들 삭제 부분 구현 (테스트 완)
## 작업사항
## 변경로직

- 삭제시 @DeleteMapping 사용하기로 했으나 requestBody가 들어가야하기 때문에 @PutMapping으로 바꿨습니다. 
<img width="1096" alt="스크린샷 2023-10-25 오후 4 50 25" src="https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/59862752/efcda101-e7b2-4ca9-8cbc-03312a3f16cd">

<img width="917" alt="스크린샷 2023-10-25 오후 4 49 49" src="https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/59862752/8c86d3e3-9bb2-400a-af7c-4ac2ef60093f">

## 사용방법
- 삭제 test request http 파일 활용하시면 됩니다.

## 기타

여정 순서를 기존 사용자가 입력받도록 했는데,, 
startDate 기준으로 순서를 자동으로 만들어주게 할까 고민입니다. 
