### PR TITLE
[fix] 회의대로 여정 이동 테이블(엔티티) 필드 수정했습니다. 

### DIFF
--- a/src/main/java/com/fastcampus/toyproject/common/exception/ExceptionCode.java
+++ b/src/main/java/com/fastcampus/toyproject/common/exception/ExceptionCode.java
@@ -12,7 +12,8 @@ public enum ExceptionCode {
     INTERNAL_SERVER_ERROR("서버에 오류가 발생했습니다."),
     INVALID_REQUEST("잘못된 요청입니다."),
     NO_SUCH_TRIP("해당하는 Trip이 없습니다."),
-
+    ILLEGAL_ARGUMENT_DEPARTUREPLACE("출발지를 입력하지 않았습니다."),
+    ILLEGAL_ARGUMENT_ARRIVALPLACE("도착지를 입력하지 않았습니다."),
     ;
 
     private String msg;

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryRequest.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryRequest.java
@@ -2,10 +2,16 @@ package com.fastcampus.toyproject.domain.itinerary.dto;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
+
+import com.fastcampus.toyproject.common.exception.DefaultException;
+import com.fastcampus.toyproject.common.exception.ExceptionCode;
 import lombok.*;
 import org.hibernate.validator.constraints.Range;
 
 import java.time.LocalDateTime;
+
+import static com.fastcampus.toyproject.common.exception.ExceptionCode.ILLEGAL_ARGUMENT_ARRIVALPLACE;
+import static com.fastcampus.toyproject.common.exception.ExceptionCode.ILLEGAL_ARGUMENT_DEPARTUREPLACE;
 
 @Getter
 @ToString
@@ -33,5 +39,16 @@ public class ItineraryRequest {
 
     private String departurePlace;
     private String arrivalPlace;
+
+    public String getMovementName() {
+        if (this.departurePlace == null) {
+            throw new DefaultException(ILLEGAL_ARGUMENT_DEPARTUREPLACE);
+        }
+        if (this.arrivalPlace == null) {
+            throw new DefaultException(ILLEGAL_ARGUMENT_ARRIVALPLACE);
+        }
+
+        return this.departurePlace + " -> " + this.arrivalPlace;
+    }
 
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryResponse.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryResponse.java
@@ -12,18 +12,19 @@ import javax.validation.constraints.Size;
 import java.time.LocalDateTime;
 
 @Getter
-@ToString
 @SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
 public class ItineraryResponse {
 
+    private Long id;
     private String itineraryName;
     private Integer itineraryOrder;
     private String itineraryType;
 
     public static ItineraryResponse fromEntity(Itinerary itinerary) {
         return ItineraryResponse.builder()
+                .id(itinerary.getItineraryId())
                 .itineraryName(itinerary.getItineraryName())
                 .itineraryOrder(itinerary.getItineraryOrder())
                 .build()

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/LodgementResponse.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/LodgementResponse.java
@@ -8,7 +8,6 @@ import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 @Getter
-@ToString
 @SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
@@ -19,6 +18,7 @@ public class LodgementResponse extends ItineraryResponse{
     public static LodgementResponse fromEntity(Lodgement entity) {
         return LodgementResponse
                 .builder()
+                .id(entity.getItineraryId())
                 .itineraryName(entity.getItineraryName())
                 .itineraryOrder(entity.getItineraryOrder())
                 .itineraryType("Lodgement")

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/MovementResponse.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/MovementResponse.java
@@ -17,6 +17,7 @@ public class MovementResponse extends ItineraryResponse {
     private LocalDateTime arrivalDate;
     private String departurePlace;
     private String arrivalPlace;
+    private String transportation;
 
     public static MovementResponse fromEntity(Movement entity) {
         return MovementResponse
@@ -28,6 +29,7 @@ public class MovementResponse extends ItineraryResponse {
                 .arrivalDate(entity.getArrivalDate())
                 .departurePlace(entity.getDeparturePlace())
                 .arrivalPlace(entity.getArrivalPlace())
+                .transportation(entity.getTransportation())
                 .build();
     }
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/MovementResponse.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/MovementResponse.java
@@ -8,7 +8,6 @@ import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 @Getter
-@ToString
 @SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
@@ -22,6 +21,7 @@ public class MovementResponse extends ItineraryResponse {
     public static MovementResponse fromEntity(Movement entity) {
         return MovementResponse
                 .builder()
+                .id(entity.getItineraryId())
                 .itineraryName(entity.getItineraryName())
                 .itineraryOrder(entity.getItineraryOrder())
                 .itineraryType("Movement")

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/StayResponse.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/StayResponse.java
@@ -8,7 +8,6 @@ import lombok.experimental.SuperBuilder;
 import java.time.LocalDateTime;
 
 @Getter
-@ToString
 @SuperBuilder
 @AllArgsConstructor
 @NoArgsConstructor
@@ -19,6 +18,7 @@ public class StayResponse extends ItineraryResponse {
     public static StayResponse fromEntity(Stay entity) {
         return StayResponse
                 .builder()
+                .id(entity.getItineraryId())
                 .itineraryName(entity.getItineraryName())
                 .itineraryOrder(entity.getItineraryOrder())
                 .itineraryType("Stay")

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Movement.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Movement.java
@@ -27,4 +27,7 @@ public class Movement extends Itinerary {
 
     @Column(nullable = false)
     private String arrivalPlace;
+
+    @Column(nullable = false)
+    private String transportation;
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
@@ -18,6 +18,7 @@ import java.util.*;
 @Service
 @RequiredArgsConstructor
 public class ItineraryService {
+
     private final TripRepository tripRepository;
     private final ItineraryRepository itineraryRepository;
     private final LodgementRepository lodgementRepository;
@@ -25,7 +26,7 @@ public class ItineraryService {
     private final StayRepository stayRepository;
 
     @Transactional
-    public List<ItineraryResponse> insertItineraries (
+    public List<ItineraryResponse> insertItineraries(
             Long tripId,
             List<ItineraryRequest> request
     ) {
@@ -47,42 +48,42 @@ public class ItineraryService {
 
             switch (ir.getType()) {
                 case 1:
-                    itinerary = Movement
-                            .builder()
-                            .tripId(trip)
-                            .itineraryName(ir.getMovementName())
-                            .itineraryOrder(ir.getOrder())
-                            .departureDate(ir.getStartDate())
-                            .arrivalDate(ir.getEndDate())
-                            .departurePlace(ir.getDeparturePlace())
-                            .arrivalPlace(ir.getArrivalPlace())
-                            .transportation(ir.getName())
-                            .build();
-                    movementRepository.save((Movement) itinerary);
+                    itinerary = movementRepository.save(
+                            Movement.builder()
+                                    .tripId(trip)
+                                    .itineraryName(ir.getMovementName())
+                                    .itineraryOrder(ir.getOrder())
+                                    .departureDate(ir.getStartDate())
+                                    .arrivalDate(ir.getEndDate())
+                                    .departurePlace(ir.getDeparturePlace())
+                                    .arrivalPlace(ir.getArrivalPlace())
+                                    .transportation(ir.getName())
+                                    .build()
+                    );
                     itineraryResponse = MovementResponse.fromEntity((Movement) itinerary);
                     break;
                 case 2:
-                    itinerary = Lodgement
-                            .builder()
-                            .tripId(trip)
-                            .itineraryName(ir.getName())
-                            .itineraryOrder(ir.getOrder())
-                            .checkIn(ir.getStartDate())
-                            .checkOut(ir.getEndDate())
-                            .build();
-                    lodgementRepository.save((Lodgement) itinerary);
+                    itinerary = lodgementRepository.save(
+                            Lodgement.builder()
+                                    .tripId(trip)
+                                    .itineraryName(ir.getName())
+                                    .itineraryOrder(ir.getOrder())
+                                    .checkIn(ir.getStartDate())
+                                    .checkOut(ir.getEndDate())
+                                    .build()
+                    );
                     itineraryResponse = LodgementResponse.fromEntity((Lodgement) itinerary);
                     break;
                 case 3:
-                    itinerary = Stay
-                            .builder()
-                            .tripId(trip)
-                            .itineraryName(ir.getName())
-                            .itineraryOrder(ir.getOrder())
-                            .departureDate(ir.getStartDate())
-                            .arrivalDate(ir.getEndDate())
-                            .build();
-                    stayRepository.save((Stay) itinerary);
+                    itinerary = stayRepository.save(
+                            Stay.builder()
+                                    .tripId(trip)
+                                    .itineraryName(ir.getName())
+                                    .itineraryOrder(ir.getOrder())
+                                    .departureDate(ir.getStartDate())
+                                    .arrivalDate(ir.getEndDate())
+                                    .build()
+                    );
                     itineraryResponse = StayResponse.fromEntity((Stay) itinerary);
                     break;
             }
@@ -94,7 +95,8 @@ public class ItineraryService {
         ItineraryValidation.validateItinerariesOrder(itineraries);
 
         //4. response 리스트 정렬. (오더 순서대로)
-        Collections.sort(itineraryResponses, Comparator.comparingInt(ItineraryResponse::getItineraryOrder));
+        Collections.sort(itineraryResponses,
+                Comparator.comparingInt(ItineraryResponse::getItineraryOrder));
 
         return itineraryResponses;
 
@@ -119,8 +121,7 @@ public class ItineraryService {
                     .findById(id)
                     .orElseThrow(() -> new DefaultException(
                             ExceptionCode.NO_ITINERARY
-                    ))
-                    ;
+                    ));
             it.delete(LocalDateTime.now());
             it.updateDeleted();
         }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
@@ -1,5 +1,7 @@
 package com.fastcampus.toyproject.domain.itinerary.service;
 
+import static com.fastcampus.toyproject.common.exception.ExceptionCode.NO_SUCH_TRIP;
+
 import com.fastcampus.toyproject.common.exception.DefaultException;
 import com.fastcampus.toyproject.common.exception.ExceptionCode;
 import com.fastcampus.toyproject.domain.itinerary.dto.*;
@@ -31,7 +33,7 @@ public class ItineraryService {
             List<ItineraryRequest> request
     ) {
 
-        List<ItineraryResponse> itineraryResponses = new ArrayList<>();
+        List<ItineraryResponse> itineraryResponseList = new ArrayList<>();
 
         //0. tripid를 통한 trip 객체 찾기. (method : getTrip(tripId))
         Trip trip = getTrip(tripId);
@@ -88,24 +90,24 @@ public class ItineraryService {
                     break;
             }
             itineraries.add(itinerary);
-            itineraryResponses.add(itineraryResponse);
+            itineraryResponseList.add(itineraryResponse);
         }
 
         //3. 검증
         ItineraryValidation.validateItinerariesOrder(itineraries);
 
         //4. response 리스트 정렬. (오더 순서대로)
-        Collections.sort(itineraryResponses,
+        Collections.sort(itineraryResponseList,
                 Comparator.comparingInt(ItineraryResponse::getItineraryOrder));
 
-        return itineraryResponses;
+        return itineraryResponseList;
 
     }
 
     private Trip getTrip(Long tripId) {
         return tripRepository
                 .findById(tripId)
-                .orElseThrow(() -> new RuntimeException("해당되는 여행이 없습니다.")
+                .orElseThrow(() -> new DefaultException(NO_SUCH_TRIP)
                 );
     }
 
@@ -135,7 +137,7 @@ public class ItineraryService {
 
         List<ItineraryResponse> itineraryResponseList = new ArrayList<>();
         for (int order = 1; order <= itineraries.size(); order++) {
-            //리스트 순대로 order 재정의.
+            //리스트 순대로 order update
             Itinerary it = itineraries.get(order - 1);
             it.updateItineraryOrder(order);
             itineraryResponseList.add(ItineraryResponse.fromEntity(it));

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
@@ -47,23 +47,16 @@ public class ItineraryService {
 
             switch (ir.getType()) {
                 case 1:
-                    if (ir.getDeparturePlace() == null) {
-                        throw new RuntimeException("이동의 경우 출발지 입력 하셔야 합니다.");
-                    }
-
-                    if (ir.getArrivalPlace() == null) {
-                        throw new RuntimeException("이동의 경우 도착지 입력 하셔야 합니다.");
-                    }
-
                     itinerary = Movement
                             .builder()
                             .tripId(trip)
-                            .itineraryName(ir.getName())
+                            .itineraryName(ir.getMovementName())
                             .itineraryOrder(ir.getOrder())
                             .departureDate(ir.getStartDate())
                             .arrivalDate(ir.getEndDate())
                             .departurePlace(ir.getDeparturePlace())
                             .arrivalPlace(ir.getArrivalPlace())
+                            .transportation(ir.getName())
                             .build();
                     movementRepository.save((Movement) itinerary);
                     itineraryResponse = MovementResponse.fromEntity((Movement) itinerary);


### PR DESCRIPTION
## 개요
여정 이동 엔티티의 필드 수정했습니다. 
또한 여정 responseDTO 에 id 필드 추가했습니다. 
## 작업사항
## 변경로직
### 변경전
기존 : 여정 - 이동에서 name은 '비행기', '버스' 같은 교통수단이었습니다. 

<img width="917" alt="스크린샷 2023-10-25 오후 4 49 49" src="https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/59862752/e69e6c2f-529e-4368-b2da-432f762fa076">

### 변경후
이동 : 출발지 -> 도착지 로 변경했습니다. 즉 여정 레코드 이름에는 위치정보가 들어가게됩니다. 
이동 테이블에는 교통수단 필드가 추가됩니다. 
<img width="919" alt="스크린샷 2023-10-25 오후 5 39 45" src="https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/59862752/50eb77fc-56e6-462e-9891-7a783e1d3675">

DB에도 동일하게 저장됩니다.

## 사용방법

## 기타
