### PR TITLE
[feat] 여행 조회 기능

### DIFF
--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Itinerary.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Itinerary.java
@@ -2,6 +2,7 @@ package com.fastcampus.toyproject.domain.itinerary.entity;
 
 import com.fastcampus.toyproject.common.BaseTimeEntity;
 import com.fastcampus.toyproject.domain.trip.entity.Trip;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorColumn;
@@ -40,6 +41,7 @@ public abstract class Itinerary {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "tripId")
+    @JsonIgnore
     private Trip tripId;
 
     @Column(nullable = false)

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/controller/TripController.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/controller/TripController.java
@@ -3,6 +3,7 @@ package com.fastcampus.toyproject.domain.trip.controller;
 
 import com.fastcampus.toyproject.common.dto.ResponseDTO;
 import com.fastcampus.toyproject.domain.trip.dto.TripDTO;
+import com.fastcampus.toyproject.domain.trip.dto.TripDetailDTO;
 import com.fastcampus.toyproject.domain.trip.entity.Trip;
 import com.fastcampus.toyproject.domain.trip.service.TripService;
 import java.util.List;
@@ -21,7 +22,18 @@ public class TripController {
 
     @GetMapping("/trips")
     public ResponseDTO<List<TripDTO>> getAllTrips(){
-        return ResponseDTO.ok("모든 Trip들을 가져왔습니다.",tripService.getAllTrips());
+        return ResponseDTO.ok
+            ("모든 Trip들을 가져왔습니다.",tripService.getAllTrips()
+            );
+    }
+
+    @GetMapping("/trips/{tripId}")
+    public ResponseDTO<TripDetailDTO> getTripDetail(
+        @PathVariable Long tripId
+    ) {
+        return ResponseDTO.ok
+            ("선택한 Trip의 정보를 가져왔습니다.", tripService.getTripDetail(tripId)
+            );
     }
 
     @PostMapping

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/controller/TripController.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/controller/TripController.java
@@ -5,6 +5,7 @@ import com.fastcampus.toyproject.common.dto.ResponseDTO;
 import com.fastcampus.toyproject.domain.trip.dto.TripDTO;
 import com.fastcampus.toyproject.domain.trip.entity.Trip;
 import com.fastcampus.toyproject.domain.trip.service.TripService;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import org.springframework.http.ResponseEntity;
@@ -15,8 +16,13 @@ import org.springframework.web.bind.annotation.*;
 public class TripController {
 
 
-    @Autowired
+    @Autowired //final&request로 바꾸고 Autowired 안 해도 되지 않을까요?
     private TripService tripService;
+
+    @GetMapping("/trips")
+    public ResponseDTO<List<TripDTO>> getAllTrips(){
+        return ResponseDTO.ok("모든 Trip들을 가져왔습니다.",tripService.getAllTrips());
+    }
 
     @PostMapping
     public ResponseEntity<ResponseDTO<Trip>> insertTrip(@PathVariable Long memberId,

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/dto/TripDTO.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/dto/TripDTO.java
@@ -1,5 +1,6 @@
 package com.fastcampus.toyproject.domain.trip.dto;
 
+import com.fastcampus.toyproject.domain.trip.entity.Trip;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,7 +10,10 @@ import lombok.NoArgsConstructor;
 @Getter
 @Builder
 @AllArgsConstructor
+
 @NoArgsConstructor
+/* TripDTO도 response, request 분리하면 어떨까요 ex) 중첩 클래스 or 여정처럼 각각 클래스*/
+
 public class TripDTO {
 
     private Long memberId;
@@ -19,6 +23,13 @@ public class TripDTO {
     private Boolean isDomestic;
 
 
-
-
+    //response로 분리(response 할 때는 Trip id 반환 안 했음)
+    public static TripDTO fromEntity(Trip trip) {
+        return TripDTO.builder()
+            .tripName(trip.getTripName())
+            .startDate(trip.getStartDate())
+            .endDate(trip.getEndDate())
+            .isDomestic(trip.getIsDomestic())
+            .build();
+    }
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/dto/TripDTO.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/dto/TripDTO.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 
 public class TripDTO {
 
-    private Long memberId;
+    private Long tripId;
     private String tripName;
     private LocalDateTime startDate;
     private LocalDateTime endDate;
@@ -26,6 +26,7 @@ public class TripDTO {
     //response로 분리(response 할 때는 Trip id 반환 안 했음)
     public static TripDTO fromEntity(Trip trip) {
         return TripDTO.builder()
+            .tripId(trip.getTripId())
             .tripName(trip.getTripName())
             .startDate(trip.getStartDate())
             .endDate(trip.getEndDate())

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/dto/TripDTO.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/dto/TripDTO.java
@@ -21,16 +21,18 @@ public class TripDTO {
     private LocalDateTime startDate;
     private LocalDateTime endDate;
     private Boolean isDomestic;
+    private String itineraryNames;
 
 
     //response로 분리(response 할 때는 Trip id 반환 안 했음)
-    public static TripDTO fromEntity(Trip trip) {
+    public static TripDTO fromEntity(Trip trip, String names) {
         return TripDTO.builder()
             .tripId(trip.getTripId())
             .tripName(trip.getTripName())
             .startDate(trip.getStartDate())
             .endDate(trip.getEndDate())
             .isDomestic(trip.getIsDomestic())
+            .itineraryNames(names)
             .build();
     }
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/dto/TripDetailDTO.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/dto/TripDetailDTO.java
@@ -1,0 +1,36 @@
+package com.fastcampus.toyproject.domain.trip.dto;
+
+import com.fastcampus.toyproject.domain.itinerary.entity.Itinerary;
+import com.fastcampus.toyproject.domain.trip.entity.Trip;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+
+public class TripDetailDTO {
+
+    private Long tripId;
+    private String tripName;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    private Boolean isDomestic;
+    private List<Itinerary> itineraries;
+
+    public static TripDetailDTO fromEntity(Trip trip, List<Itinerary> itineraryList) {
+        return TripDetailDTO.builder()
+            .tripId(trip.getTripId())
+            .tripName(trip.getTripName())
+            .startDate(trip.getStartDate())
+            .endDate(trip.getEndDate())
+            .isDomestic(trip.getIsDomestic())
+            .itineraries(itineraryList)
+            .build();
+    }
+}

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/service/TripService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/service/TripService.java
@@ -10,6 +10,9 @@ import com.fastcampus.toyproject.domain.trip.repository.TripRepository;
 import java.time.LocalDateTime;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -26,6 +29,13 @@ public class TripService {
         return memberRepository.findById(memberId)
             .orElseThrow(
                 () -> new DefaultException(ExceptionCode.INVALID_REQUEST, "해당하는 멤버가 없습니다."));
+    }
+
+    @Transactional(readOnly = true)
+    public List<TripDTO> getAllTrips() {
+        return tripRepository.findAll()
+            .stream().map(TripDTO::fromEntity)
+            .collect(Collectors.toList());
     }
 
     public Trip insertTrip(Long memberId, TripDTO tripDTO) {

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/service/TripService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/service/TripService.java
@@ -14,7 +14,6 @@ import com.fastcampus.toyproject.domain.trip.dto.TripDetailDTO;
 import com.fastcampus.toyproject.domain.trip.entity.Trip;
 import com.fastcampus.toyproject.domain.trip.repository.TripRepository;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import java.util.List;
@@ -55,10 +54,20 @@ public class TripService {
             .orElseThrow(()->new DefaultException(NO_ITINERARY));
     }
 
+    private String getItineraryNamesByTripId(Long tripId) {
+        return itineraryRepository.findById(tripId)
+            .stream().map(Itinerary::getItineraryName)
+            .collect(Collectors.joining());
+    }
+
     @Transactional(readOnly = true)
     public List<TripDTO> getAllTrips() {
         return tripRepository.findAll()
-            .stream().map(TripDTO::fromEntity)
+            .stream().map(trip -> TripDTO.fromEntity
+                (
+                    trip, getItineraryNamesByTripId(trip.getTripId())
+                )
+            )
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/service/TripService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/service/TripService.java
@@ -14,6 +14,7 @@ import com.fastcampus.toyproject.domain.trip.dto.TripDetailDTO;
 import com.fastcampus.toyproject.domain.trip.entity.Trip;
 import com.fastcampus.toyproject.domain.trip.repository.TripRepository;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import java.util.List;
@@ -54,10 +55,11 @@ public class TripService {
             .orElseThrow(()->new DefaultException(NO_ITINERARY));
     }
 
-    private String getItineraryNamesByTripId(Long tripId) {
-        return itineraryRepository.findById(tripId)
+    private String getItineraryNamesByTrip(Trip trip) {
+        return itineraryRepository.findAllByTripIdAndIsDeletedNull(trip)
+            .orElse(new ArrayList<>())
             .stream().map(Itinerary::getItineraryName)
-            .collect(Collectors.joining());
+            .collect(Collectors.joining(", "));
     }
 
     @Transactional(readOnly = true)
@@ -65,7 +67,7 @@ public class TripService {
         return tripRepository.findAll()
             .stream().map(trip -> TripDTO.fromEntity
                 (
-                    trip, getItineraryNamesByTripId(trip.getTripId())
+                    trip, getItineraryNamesByTrip(trip)
                 )
             )
             .collect(Collectors.toList());

--- a/src/test/java/com/fastcampus/toyproject/http_requests/member-create-test.http
+++ b/src/test/java/com/fastcampus/toyproject/http_requests/member-create-test.http
@@ -1,2 +1,7 @@
 POST http://localhost:8080/member/
 Content-Type: application/json
+
+{
+  "memberId" : 1,
+  "nickName" : "김종훈"
+}


### PR DESCRIPTION
## 개요
getAllTrips(여행 전체 조회), getTripDetail(개별 여행 조회)를 완성했습니다.
## 작업 사항
### Trip 컨트롤러
<img width="514" alt="image" src="https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/52107658/482b1e51-25b0-493d-a62a-570386bd8f91">

### TripDTO: getAllTrips에서 사용
<img width="495" alt="image" src="https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/52107658/7c63e7fe-ec6d-4e05-b8f8-13edc9b602e7">

### TripDetailDTO: getTripDetail에서 사용
<img width="552" alt="image" src="https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/52107658/63ca4ae2-94e0-41ca-ad62-0ac4381b5adc">

### TripService: 여정 repository & service 코드 그대로 사용
<img width="565" alt="image" src="https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/52107658/773896cb-db14-4959-b158-318c0aa1c9f2">

## 남은 작업
- TripDTO의 response, request 분리는 추후에 진행할 예정입니다.
- 저희가 지금 다대일 관계를 tripID로만 repository를 찾는데, 이 방법은 외래 키를 사용하지 않아 쿼리 사용이 늘어나고 객체 지향에 맞지 않다고 합니다. 그래서 고치려 했는데 오류가 생겨서 이슈로 따로 생성할 예정입니다. 
- TripDetailDTO의 list 처리를 어떻게 해야 할지 고민 중입니다.
지금 생각한 방법: builder 제거 후 생성자로 변경
**더 좋은 방법이 있으면 부탁드립니다**


