### PR TITLE
[fix] 여정 baseEntity 상속 관련 코드 수정

### DIFF
--- a/src/main/java/com/fastcampus/toyproject/common/BaseTimeEntity.java
+++ b/src/main/java/com/fastcampus/toyproject/common/BaseTimeEntity.java
@@ -4,20 +4,25 @@ import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public abstract class BaseTimeEntity {
+public class BaseTimeEntity {
 
     @CreatedDate
     private LocalDateTime createdAt;
 
-    @Column(insertable = false)
     @LastModifiedDate
     private LocalDateTime updatedAt;
 

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Itinerary.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Itinerary.java
@@ -1,5 +1,6 @@
 package com.fastcampus.toyproject.domain.itinerary.entity;
 
+import com.fastcampus.toyproject.common.BaseTimeEntity;
 import com.fastcampus.toyproject.domain.trip.entity.Trip;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.time.LocalDateTime;
@@ -32,7 +33,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Inheritance(strategy = InheritanceType.JOINED)
 @DiscriminatorColumn
 @SuperBuilder
-public abstract class Itinerary {
+public class Itinerary extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -52,20 +53,9 @@ public abstract class Itinerary {
     @ColumnDefault("false")
     private Boolean isDeleted;
 
-    @CreatedDate
-    private LocalDateTime createdAt;
-
-    @Column(insertable = false)
-    @LastModifiedDate
-    private LocalDateTime updatedAt;
-
-    @Column(insertable = false)
-    private LocalDateTime deletedAt;
-
+    @Override
     public void delete(LocalDateTime currentTime) {
-        if (deletedAt == null) {
-            deletedAt = currentTime;
-        }
+        super.delete(currentTime);
     }
 
     public void updateDeleted() {

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/entity/Trip.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/entity/Trip.java
@@ -17,6 +17,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -25,7 +26,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+@SuperBuilder
 public class Trip extends BaseTimeEntity {
 
     @Id


### PR DESCRIPTION
## 개요
여정 entity에 baseEntity 상속 받으면서 생기는 몇가지 수정

## 작업사항
## 변경로직
### 변경전
### 변경후
1. 여정 entity 기존 추상 클래스에서 일반 클래스로 변경.
2. 여행 entity에 SuperBuilder 추가
3. baseEntity도 동일

테스트 완료

