### PR TITLE
[feat] 일시 다루는 공통 유틸리티 클래스 추가 

### DIFF
--- a/src/main/java/com/fastcampus/toyproject/common/exception/ExceptionCode.java
+++ b/src/main/java/com/fastcampus/toyproject/common/exception/ExceptionCode.java
@@ -15,6 +15,7 @@ public enum ExceptionCode {
     EMPTY_ITINERARY("수정 할 여정 정보가 없습니다."),
     ILLEGAL_ARGUMENT_DEPARTUREPLACE("출발지를 입력하지 않았습니다."),
     ILLEGAL_ARGUMENT_ARRIVALPLACE("도착지를 입력하지 않았습니다."),
+    STARTDATE_IS_LATER_THAN_ENDDATE("출발 일정이 도착 일정보다 늦습니다.")
   
     ;
 

--- a/src/main/java/com/fastcampus/toyproject/common/util/DateUtil.java
+++ b/src/main/java/com/fastcampus/toyproject/common/util/DateUtil.java
@@ -1,0 +1,66 @@
+package com.fastcampus.toyproject.common.util;
+
+import static com.fastcampus.toyproject.common.exception.ExceptionCode.STARTDATE_IS_LATER_THAN_ENDDATE;
+import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+import com.fastcampus.toyproject.common.exception.DefaultException;
+import com.fastcampus.toyproject.common.exception.ExceptionCode;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 날짜 및 일시를 다루는 공통 유틸 클래스.
+ * 기능
+ * 1. 날짜 차이 계산 (10day)
+ * 2. 시간 차이 계산 (1h 10m)
+ * 3. 출발 날짜가 도착 날짜보다 늦지는 않은지.
+ */
+public class DateUtil {
+
+    private static final String days = "days";
+    private static final String hour = "h";
+    private static final String min = "m";
+
+
+    // 몇 일 여행인지 계산 -> LocalDate
+    public static String getDaysBetweenDate(LocalDate start, LocalDate end) {
+        return String.valueOf(DAYS.toChronoUnit().between(start, end)) + days;
+    }
+
+    // 몇 일 여행(숙박)인지 계산 -> LocalDateTime
+    public static String getDaysBetweenDate(LocalDateTime start, LocalDateTime end) {
+        return String.valueOf(DAYS.toChronoUnit().between(start, end)) + days;
+    }
+
+    // 몇 시간 소모되는지 계산 -> LocalDateTime
+    public static String getTimeBetweenDate(LocalDateTime start, LocalDateTime end) {
+        StringBuilder res = new StringBuilder();
+        long hours = HOURS.toChronoUnit().between(start, end);
+        long minutes = MINUTES.toChronoUnit().between(start, end);
+
+        if (hours != 0) {
+            res.append(hours).append(hour).append(" ");
+            minutes -= hours * 60;
+        }
+
+        res.append(minutes).append(min);
+        return res.toString();
+    }
+
+    // 출발 날짜가 도착 날짜보다 빠른지 검사 -> 아니라면 예외 날림
+    public static void isStartDateEarlierThanEndDate(LocalDate start, LocalDate end) {
+        if (!start.isEqual(end) && start.isAfter(end)) {
+            throw new DefaultException(STARTDATE_IS_LATER_THAN_ENDDATE);
+        }
+    }
+
+    public static void isStartDateEarlierThanEndDate(LocalDateTime start, LocalDateTime end) {
+        if (!start.isEqual(end) && start.isAfter(end)) {
+            throw new DefaultException(STARTDATE_IS_LATER_THAN_ENDDATE);
+        }
+    }
+
+
+}

--- a/src/main/java/com/fastcampus/toyproject/common/util/DateUtil.java
+++ b/src/main/java/com/fastcampus/toyproject/common/util/DateUtil.java
@@ -31,7 +31,7 @@ public class DateUtil {
 
     // 몇 일 여행(숙박)인지 계산 -> LocalDateTime
     public static String getDaysBetweenDate(LocalDateTime start, LocalDateTime end) {
-        return String.valueOf(DAYS.toChronoUnit().between(start, end)) + days;
+        return String.valueOf(getDaysBetweenDate(start.toLocalDate(), end.toLocalDate()));
     }
 
     // 몇 시간 소모되는지 계산 -> LocalDateTime

--- a/src/test/java/com/fastcampus/toyproject/common/util/DateUtilTest.java
+++ b/src/test/java/com/fastcampus/toyproject/common/util/DateUtilTest.java
@@ -1,0 +1,49 @@
+package com.fastcampus.toyproject.common.util;
+
+import com.fastcampus.toyproject.common.exception.DefaultException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+
+class DateUtilTest {
+
+    @Test
+    void 날짜_차이_계산() {
+        LocalDate startD = LocalDate.of(2022, 11, 22);
+        LocalDate endD = LocalDate.of(2023, 10, 22);
+
+        LocalDateTime startDt = LocalDateTime.of(2023, 10, 26, 00, 40, 0);
+        LocalDateTime endDt = LocalDateTime.now();
+
+        System.out.println("날짜 차이: " + DateUtil.getDaysBetweenDate(startD, endD));
+        System.out.println("날짜 차이: " + DateUtil.getDaysBetweenDate(startDt, endDt));
+        System.out.println("시간 차이: " + DateUtil.getTimeBetweenDate(startDt, endDt));
+
+    }
+
+    @Test
+    void 출발날짜가_도착날짜보다_늦으면_에러나는지_확인_LocalDate버전() {
+        try {
+            LocalDate startD = LocalDate.of(2022, 11, 22);
+            LocalDate endD = LocalDate.of(2023, 10, 22);
+
+            DateUtil.isStartDateEarlierThanEndDate(endD, startD);
+        } catch (DefaultException e) {
+            System.out.println(e.getErrorCode() + ": " + e.getErrorMsg());
+        }
+    }
+
+    @Test
+    void 출발날짜가_도착날짜보다_늦으면_에러나는지_확인_LocalDateTime버전() {
+        try {
+            LocalDateTime startDt = LocalDateTime.of(2023, 10, 26, 00, 40, 0);
+            LocalDateTime endDt = LocalDateTime.now();
+
+            //DateUtil.isStartDateEarlierThanEndDate(startDt, endDt);
+            DateUtil.isStartDateEarlierThanEndDate(endDt, startDt);
+        } catch (DefaultException e) {
+            System.out.println(e.getErrorCode() + ": " + e.getErrorMsg());
+        }
+    }
+
+}


### PR DESCRIPTION
## 개요
- LocalDateTime, LocalDate를 다루는 공통 유틸리티 클래스입니다.
- 다음과 같은 기능을 다룹니다.

```
 * 날짜 및 일시를 다루는 공통 유틸 클래스.
 * 기능
 * 1. 날짜 차이 계산 (10day)
 * 2. 시간 차이 계산 (1h 10m)
 * 3. 출발 날짜가 도착 날짜보다 늦지는 않은지.
``` 

테스트 완료 

## 작업사항

결과 화면 
#### 날짜(시간) 차이 응답 response
같은 날짜인 경우 0days가 뜨는게 맞습니다.
<img width="832" alt="스크린샷 2023-10-26 오후 5 56 28" src="https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/59862752/330d672a-ac17-434f-bff8-d94eb8e5d636">
 


#### 에러 처리 : 출발 시간이 도착 시간보다 늦을 때?

<img width="636" alt="스크린샷 2023-10-26 오후 5 55 32" src="https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/59862752/66cef8c7-0e7b-427d-b9ae-4a0292a3da49">

## 변경로직
## 사용방법

** 응답 DTO에서는 변수 선언후 담아야합니다. 
```java
public class LodgementResponse extends ItineraryResponse{
    private LocalDateTime checkIn;
    private LocalDateTime checkOut;

    private String dayDifference;

    public static LodgementResponse fromEntity(Lodgement entity) {
        return LodgementResponse
                .builder()
                .checkIn(entity.getCheckIn())
                .checkOut(entity.getCheckOut())
                .dayDifference(DateUtil.getDaysBetweenDate(entity.getCheckIn(), entity.getCheckOut()))
                .build();
    }
}
``` 

** 출발 시간이 도착 시간보다 늦지 않는지 확인 (서비스 로직)
![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/59862752/e9416a62-a6b2-4a76-8bfb-a0bce959eab5)
 

## 기타

출발 시간이 도착 시간보다 늦지 않는 확인 에러는 컨트롤러 상에서 처리해야할지, 서비스에서 처리해야할지 모르겠습니다. 
