### PR TITLE
[fix] 여행 여정 다대일 관계 수정 및 리팩토링

### DIFF
--- a/src/main/java/com/fastcampus/toyproject/common/exception/DefaultExceptionHandler.java
+++ b/src/main/java/com/fastcampus/toyproject/common/exception/DefaultExceptionHandler.java
@@ -1,9 +1,13 @@
 package com.fastcampus.toyproject.common.exception;
 
+import static com.fastcampus.toyproject.common.exception.ExceptionCode.BAD_REQUEST;
+
 import com.fastcampus.toyproject.common.dto.ErrorResponseDTO;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -40,20 +44,43 @@ public class DefaultExceptionHandler {
     }
 
     /**
-     * 커스텀 에러를 제외한 나머지 에러들 처리 (추후 수정 예정) -> badRequset 만 중점으로 받을지 고민됨
+     * 커스텀 에러를 제외한 badRequset 만 중점으로 처리하는 에러 핸들러
      * @param
      * @param request
      * @return
      */
     @ExceptionHandler(value = {
             HttpRequestMethodNotSupportedException.class,
+            HttpMessageNotReadableException.class,
             MethodArgumentNotValidException.class,
-            Exception.class
+            InvalidFormatException.class
     })
     public ResponseEntity<ErrorResponseDTO> handleBadRequest(
             Exception e, HttpServletRequest request
     ) {
-        log.error("error!!!! url : {}, message : {}",
+        log.error("request error url : {}, message : {}",
+                request.getRequestURI(),
+                e.getMessage()
+        );
+
+        return new ResponseEntity<>(
+                ErrorResponseDTO.error(
+                        BAD_REQUEST,
+                        BAD_REQUEST.getMsg()
+                ),
+                HttpStatus.BAD_REQUEST
+
+        );
+    }
+
+    @ExceptionHandler(value = {
+            Exception.class
+    })
+    public ResponseEntity<ErrorResponseDTO> handleException(
+            Exception e, HttpServletRequest request
+    ) {
+        log.error("exception error class : {}, url : {}, message : {}",
+                e.getClass(),
                 request.getRequestURI(),
                 e.getMessage()
         );

--- a/src/main/java/com/fastcampus/toyproject/common/exception/ExceptionCode.java
+++ b/src/main/java/com/fastcampus/toyproject/common/exception/ExceptionCode.java
@@ -10,6 +10,7 @@ public enum ExceptionCode {
     DUPLICATE_ITINERARY_ORDER("여정 순서가 중복됩니다."),
     INCORRECT_ORDER("잘못된 여정 순서입니다."),
     INTERNAL_SERVER_ERROR("서버에 오류가 발생했습니다."),
+    BAD_REQUEST("잘못된 입력값 입니다."),
     INVALID_REQUEST("잘못된 요청입니다."),
     NO_SUCH_TRIP("해당하는 Trip이 없습니다."),
     EMPTY_ITINERARY("수정 할 여정 정보가 없습니다."),

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/controller/ItineraryController.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/controller/ItineraryController.java
@@ -1,6 +1,7 @@
 package com.fastcampus.toyproject.domain.itinerary.controller;
 
 import com.fastcampus.toyproject.common.dto.ResponseDTO;
+import com.fastcampus.toyproject.common.util.DateUtil;
 import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryRequest;
 import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryResponse;
 import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryUpdateRequest;
@@ -20,9 +21,12 @@ public class ItineraryController {
     @PostMapping("/{tripId}")
     public ResponseDTO<List<ItineraryResponse>> insertItineraries(
             @PathVariable final Long tripId,
-            @Valid @RequestBody final List<ItineraryRequest> request
+            @Valid @RequestBody final List<ItineraryRequest> itineraryRequests
     ) {
-        return ResponseDTO.ok("여정들 삽입 완료", itineraryService.insertItineraries(tripId, request));
+        for (ItineraryRequest ir : itineraryRequests) {
+            DateUtil.isStartDateEarlierThanEndDate(ir.getStartDate(), ir.getEndDate());
+        }
+        return ResponseDTO.ok("여정들 삽입 완료", itineraryService.insertItineraries(tripId, itineraryRequests));
     }
 
     @PutMapping("/delete/{tripId}")
@@ -38,7 +42,11 @@ public class ItineraryController {
         @PathVariable final Long tripId,
         @Valid @RequestBody List<ItineraryUpdateRequest> itineraryUpdateRequests) {
 
-        List<ItineraryResponse> itineraryResponses = itineraryService.updateItinerary(tripId,
+        for (ItineraryRequest ir : itineraryUpdateRequests) {
+            DateUtil.isStartDateEarlierThanEndDate(ir.getStartDate(), ir.getEndDate());
+        }
+
+        List<ItineraryResponse> itineraryResponses = itineraryService.updateItineraries(tripId,
             itineraryUpdateRequests);
 
         return ResponseDTO.ok("여정들 수정 완료", itineraryResponses);

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryRequest.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryRequest.java
@@ -1,13 +1,12 @@
 package com.fastcampus.toyproject.domain.itinerary.dto;
 
+import com.fastcampus.toyproject.domain.itinerary.type.ItineraryType;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import com.fastcampus.toyproject.common.exception.DefaultException;
-import com.fastcampus.toyproject.common.exception.ExceptionCode;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import org.hibernate.validator.constraints.Range;
 
 import java.time.LocalDateTime;
 
@@ -22,11 +21,10 @@ import static com.fastcampus.toyproject.common.exception.ExceptionCode.ILLEGAL_A
 public class ItineraryRequest {
 
     @NotNull
-    @Range(min = 1, max = 3)
-    private Integer type;
+    private ItineraryType type;
 
     @NotNull
-    private String name;
+    private String item;
 
     @NotNull
     private LocalDateTime startDate;

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryResponse.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryResponse.java
@@ -27,7 +27,6 @@ public class ItineraryResponse {
                 .id(itinerary.getItineraryId())
                 .itineraryName(itinerary.getItineraryName())
                 .itineraryOrder(itinerary.getItineraryOrder())
-                .itineraryType(itinerary.getItineraryName())
                 .build();
     }
 

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/LodgementResponse.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/LodgementResponse.java
@@ -1,6 +1,9 @@
 package com.fastcampus.toyproject.domain.itinerary.dto;
 
+import static com.fastcampus.toyproject.domain.itinerary.type.ItineraryType.LODGEMENT;
+
 import com.fastcampus.toyproject.domain.itinerary.entity.Lodgement;
+import com.fastcampus.toyproject.domain.itinerary.type.ItineraryType;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
@@ -21,7 +24,7 @@ public class LodgementResponse extends ItineraryResponse{
                 .id(entity.getItineraryId())
                 .itineraryName(entity.getItineraryName())
                 .itineraryOrder(entity.getItineraryOrder())
-                .itineraryType("Lodgement")
+                .itineraryType(LODGEMENT.getValue())
                 .checkIn(entity.getCheckIn())
                 .checkOut(entity.getCheckOut())
                 .build();

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/LodgementResponse.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/LodgementResponse.java
@@ -2,6 +2,7 @@ package com.fastcampus.toyproject.domain.itinerary.dto;
 
 import static com.fastcampus.toyproject.domain.itinerary.type.ItineraryType.LODGEMENT;
 
+import com.fastcampus.toyproject.common.util.DateUtil;
 import com.fastcampus.toyproject.domain.itinerary.entity.Lodgement;
 import com.fastcampus.toyproject.domain.itinerary.type.ItineraryType;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
@@ -17,6 +18,7 @@ import java.time.LocalDateTime;
 public class LodgementResponse extends ItineraryResponse{
     private LocalDateTime checkIn;
     private LocalDateTime checkOut;
+    private String dayDifference;
 
     public static LodgementResponse fromEntity(Lodgement entity) {
         return LodgementResponse
@@ -27,6 +29,7 @@ public class LodgementResponse extends ItineraryResponse{
                 .itineraryType(LODGEMENT.getValue())
                 .checkIn(entity.getCheckIn())
                 .checkOut(entity.getCheckOut())
+                .dayDifference(DateUtil.getDaysBetweenDate(entity.getCheckIn(), entity.getCheckOut()))
                 .build();
     }
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/MovementResponse.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/MovementResponse.java
@@ -1,6 +1,9 @@
 package com.fastcampus.toyproject.domain.itinerary.dto;
 
+import static com.fastcampus.toyproject.domain.itinerary.type.ItineraryType.MOVEMENT;
+
 import com.fastcampus.toyproject.domain.itinerary.entity.Movement;
+import com.fastcampus.toyproject.domain.itinerary.type.ItineraryType;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
@@ -24,7 +27,7 @@ public class MovementResponse extends ItineraryResponse {
                 .id(entity.getItineraryId())
                 .itineraryName(entity.getItineraryName())
                 .itineraryOrder(entity.getItineraryOrder())
-                .itineraryType("Movement")
+                .itineraryType(MOVEMENT.getValue())
                 .departureDate(entity.getDepartureDate())
                 .arrivalDate(entity.getArrivalDate())
                 .departurePlace(entity.getDeparturePlace())

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/MovementResponse.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/MovementResponse.java
@@ -2,6 +2,7 @@ package com.fastcampus.toyproject.domain.itinerary.dto;
 
 import static com.fastcampus.toyproject.domain.itinerary.type.ItineraryType.MOVEMENT;
 
+import com.fastcampus.toyproject.common.util.DateUtil;
 import com.fastcampus.toyproject.domain.itinerary.entity.Movement;
 import com.fastcampus.toyproject.domain.itinerary.type.ItineraryType;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
@@ -20,6 +21,7 @@ public class MovementResponse extends ItineraryResponse {
     private String departurePlace;
     private String arrivalPlace;
     private String transportation;
+    private String timeDifference;
 
     public static MovementResponse fromEntity(Movement entity) {
         return MovementResponse
@@ -33,6 +35,7 @@ public class MovementResponse extends ItineraryResponse {
                 .departurePlace(entity.getDeparturePlace())
                 .arrivalPlace(entity.getArrivalPlace())
                 .transportation(entity.getTransportation())
+                .timeDifference(DateUtil.getTimeBetweenDate(entity.getDepartureDate(), entity.getArrivalDate()))
                 .build();
     }
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/StayResponse.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/StayResponse.java
@@ -2,6 +2,7 @@ package com.fastcampus.toyproject.domain.itinerary.dto;
 
 import static com.fastcampus.toyproject.domain.itinerary.type.ItineraryType.STAY;
 
+import com.fastcampus.toyproject.common.util.DateUtil;
 import com.fastcampus.toyproject.domain.itinerary.entity.Stay;
 import com.fastcampus.toyproject.domain.itinerary.type.ItineraryType;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
@@ -17,6 +18,7 @@ import java.time.LocalDateTime;
 public class StayResponse extends ItineraryResponse {
     private LocalDateTime departureDate;
     private LocalDateTime arrivalDate;
+    private String timeDifference;
 
     public static StayResponse fromEntity(Stay entity) {
         return StayResponse
@@ -27,6 +29,7 @@ public class StayResponse extends ItineraryResponse {
                 .itineraryType(STAY.getValue())
                 .departureDate(entity.getDepartureDate())
                 .arrivalDate(entity.getArrivalDate())
+                .timeDifference(DateUtil.getTimeBetweenDate(entity.getDepartureDate(), entity.getArrivalDate()))
                 .build();
     }
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/StayResponse.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/StayResponse.java
@@ -1,6 +1,9 @@
 package com.fastcampus.toyproject.domain.itinerary.dto;
 
+import static com.fastcampus.toyproject.domain.itinerary.type.ItineraryType.STAY;
+
 import com.fastcampus.toyproject.domain.itinerary.entity.Stay;
+import com.fastcampus.toyproject.domain.itinerary.type.ItineraryType;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
@@ -21,7 +24,7 @@ public class StayResponse extends ItineraryResponse {
                 .id(entity.getItineraryId())
                 .itineraryName(entity.getItineraryName())
                 .itineraryOrder(entity.getItineraryOrder())
-                .itineraryType("Stay")
+                .itineraryType(STAY.getValue())
                 .departureDate(entity.getDepartureDate())
                 .arrivalDate(entity.getArrivalDate())
                 .build();

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Itinerary.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Itinerary.java
@@ -21,8 +21,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.ColumnDefault;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
@@ -42,7 +40,7 @@ public class Itinerary extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "tripId")
     @JsonIgnore
-    private Trip tripId;
+    private Trip trip;
 
     @Column(nullable = false)
     private String itineraryName;
@@ -53,12 +51,8 @@ public class Itinerary extends BaseTimeEntity {
     @ColumnDefault("false")
     private Boolean isDeleted;
 
-    @Override
-    public void delete(LocalDateTime currentTime) {
-        super.delete(currentTime);
-    }
-
-    public void updateDeleted() {
+    public void delete() {
+        super.delete(LocalDateTime.now());
         this.isDeleted = true;
     }
 

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Lodgement.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Lodgement.java
@@ -23,7 +23,7 @@ public class Lodgement extends Itinerary {
     private LocalDateTime checkOut;
 
     public void updateLodgement(ItineraryUpdateRequest req){
-        super.updateItineraryName(req.getName());
+        super.updateItineraryName(req.getItem());
         super.updateItineraryOrder(req.getOrder());
         this.checkIn = req.getStartDate();
         this.checkOut = req.getEndDate();

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Movement.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Movement.java
@@ -35,7 +35,7 @@ public class Movement extends Itinerary {
     public void updateMovement(ItineraryUpdateRequest req) {
         super.updateItineraryName(req.getMovementName());
         super.updateItineraryOrder(req.getOrder());
-        this.transportation = req.getName();
+        this.transportation = req.getItem();
         this.departureDate = req.getStartDate();
         this.departurePlace = req.getDeparturePlace();
         this.arrivalDate = req.getEndDate();

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Stay.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Stay.java
@@ -23,7 +23,7 @@ public class Stay extends Itinerary {
     private LocalDateTime arrivalDate;
 
     public void updateStay(ItineraryUpdateRequest req){
-        super.updateItineraryName(req.getName());
+        super.updateItineraryName(req.getItem());
         super.updateItineraryOrder(req.getOrder());
         this.departureDate = req.getStartDate();
         this.arrivalDate = req.getEndDate();

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/repository/ItineraryRepository.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/repository/ItineraryRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 @Repository
 public interface ItineraryRepository extends JpaRepository<Itinerary, Long> {
-    Optional<List<Itinerary>> findAllByTripIdAndIsDeletedNull(Trip tripId);
+    Optional<List<Itinerary>> findAllByTripAndIsDeletedNull(Trip trip);
 
-    List<Itinerary> findAllByTripIdOrderByItineraryOrder(Trip tripId);
+    List<Itinerary> findAllByTripOrderByItineraryOrder(Trip trip);
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
@@ -185,10 +185,7 @@ public class ItineraryService {
         }
 
         //2. 남은 여정들의 순서 재정의
-        List<Itinerary> itineraries = itineraryRepository
-                .findAllByTripAndIsDeletedNull(getTrip(tripId))
-                .orElseGet(ArrayList::new);
-
+        List<Itinerary> itineraries = getItineraryList(getTrip(tripId));
         Collections.sort(itineraries, Comparator.comparingInt(Itinerary::getItineraryOrder));
 
         List<ItineraryResponse> itineraryResponseList = new ArrayList<>();
@@ -263,25 +260,17 @@ public class ItineraryService {
                     break;
                 case STAY:
                     Stay stay = stayRepository.findById(req.getItineraryId()).orElseThrow(
-                        () -> new DefaultException(ExceptionCode.NO_SUCH_TRIP));
+                        () -> new DefaultException(ExceptionCode.NO_ITINERARY));
 
                     stay.updateStay(req);
                     itineraryResponseList.add(ItineraryResponse.fromEntity(stay));
-
-//                    stayRepository.flush();
 
                     break;
             }
 
         }
 
-        List<Itinerary> itineraryList = itineraryRepository.findAllByTripOrderByItineraryOrder(
-            getTrip(tripId));
-
-        ItineraryValidation.validateItinerariesOrder(itineraryList);
-        sortItineraryResponseListByOrder(itineraryResponseList);
-
-        return itineraryResponseList;
+        return getItineraryListByTrip(getTrip(tripId));
     }
 
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
@@ -4,17 +4,18 @@ import static com.fastcampus.toyproject.common.exception.ExceptionCode.NO_SUCH_T
 
 import com.fastcampus.toyproject.common.exception.DefaultException;
 import com.fastcampus.toyproject.common.exception.ExceptionCode;
+import com.fastcampus.toyproject.common.util.DateUtil;
 import com.fastcampus.toyproject.domain.itinerary.dto.*;
 import com.fastcampus.toyproject.domain.itinerary.entity.*;
 import com.fastcampus.toyproject.domain.itinerary.repository.*;
 import com.fastcampus.toyproject.domain.itinerary.util.ItineraryValidation;
 import com.fastcampus.toyproject.domain.trip.entity.Trip;
 import com.fastcampus.toyproject.domain.trip.repository.TripRepository;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.*;
 
 @Service
@@ -27,10 +28,16 @@ public class ItineraryService {
     private final MovementRepository movementRepository;
     private final StayRepository stayRepository;
 
+    /**
+     * itinerary (1개 이상) 삽입하는 메소드
+     * @param tripId
+     * @param itineraryRequests
+     * @return
+     */
     @Transactional
     public List<ItineraryResponse> insertItineraries(
             Long tripId,
-            List<ItineraryRequest> request
+            List<ItineraryRequest> itineraryRequests
     ) {
 
         List<ItineraryResponse> itineraryResponseList = new ArrayList<>();
@@ -39,12 +46,10 @@ public class ItineraryService {
         Trip trip = getTrip(tripId);
 
         //1. 여정 테이블에서 모든 값 가져오기.
-        List<Itinerary> itineraries = itineraryRepository
-                .findAllByTripIdAndIsDeletedNull(getTrip(tripId))
-                .orElseGet(ArrayList::new);
+        List<Itinerary> itineraries = getItineraryList(trip);
 
         //2. 현 request 에서 entity로 변환하여 리스트에 추가.
-        for (ItineraryRequest ir : request) {
+        for (ItineraryRequest ir : itineraryRequests) {
             Itinerary itinerary = null;
             ItineraryResponse itineraryResponse = null;
 
@@ -52,7 +57,7 @@ public class ItineraryService {
                 case MOVEMENT:
                     itinerary = movementRepository.save(
                             Movement.builder()
-                                    .tripId(trip)
+                                    .trip(trip)
                                     .itineraryName(ir.getMovementName())
                                     .itineraryOrder(ir.getOrder())
                                     .departureDate(ir.getStartDate())
@@ -67,7 +72,7 @@ public class ItineraryService {
                 case LODGEMENT:
                     itinerary = lodgementRepository.save(
                             Lodgement.builder()
-                                    .tripId(trip)
+                                    .trip(trip)
                                     .itineraryName(ir.getItem())
                                     .itineraryOrder(ir.getOrder())
                                     .checkIn(ir.getStartDate())
@@ -79,7 +84,7 @@ public class ItineraryService {
                 case STAY:
                     itinerary = stayRepository.save(
                             Stay.builder()
-                                    .tripId(trip)
+                                    .trip(trip)
                                     .itineraryName(ir.getItem())
                                     .itineraryOrder(ir.getOrder())
                                     .departureDate(ir.getStartDate())
@@ -97,26 +102,78 @@ public class ItineraryService {
         ItineraryValidation.validateItinerariesOrder(itineraries);
 
         //4. response 리스트 정렬. (오더 순서대로)
-        Collections.sort(itineraryResponseList,
-                Comparator.comparingInt(ItineraryResponse::getItineraryOrder));
+        sortItineraryResponseListByOrder(itineraryResponseList);
 
         return itineraryResponseList;
-
     }
 
+    /**
+     * trip 객체로 연관된 itinerary 리스트를 정렬된 여정 응답 리스트로 변환하여 반환하는 메소드
+     * @param trip
+     * @return
+     */
+    public List<ItineraryResponse> getItineraryListByTrip(Trip trip) {
+        List<Itinerary> itineraryList = getItineraryList(trip);
+
+        List<ItineraryResponse> itineraryResponseList = new ArrayList<>();
+        for (Itinerary it : itineraryList) {
+            if (it instanceof Movement) {
+                itineraryResponseList.add(MovementResponse.fromEntity((Movement) it));
+            } else if (it instanceof Lodgement) {
+                itineraryResponseList.add(LodgementResponse.fromEntity((Lodgement) it));
+            } else if (it instanceof Stay) {
+                itineraryResponseList.add(StayResponse.fromEntity((Stay) it));
+            }
+        }
+
+        sortItineraryResponseListByOrder(itineraryResponseList);
+        return itineraryResponseList;
+    }
+
+    /**
+     * trip 객체를 이용하여 연관된 itinerary 리스트 반환하는 메소드
+     * @param trip
+     * @return List<Itinerary>
+     */
+    private static List<Itinerary> getItineraryList(Trip trip) {
+        List<Itinerary> itineraryList = trip.getItineraryList()
+                .stream().filter(it -> it.getIsDeleted() == null)
+                .collect(Collectors.toList());
+        if (itineraryList == null) itineraryList = new ArrayList<>();
+        return itineraryList;
+    }
+
+    /**
+     * 테이블에 등록된 여정 순서대로 itinerary 리스트 정렬
+     * @param itineraryResponseList
+     */
+    private static void sortItineraryResponseListByOrder(List<ItineraryResponse> itineraryResponseList) {
+        Collections.sort(itineraryResponseList,
+                Comparator.comparingInt(ItineraryResponse::getItineraryOrder));
+    }
+
+    /**
+     * tripService 를 이용해 trip 객체 반환하는 메소드
+     * @param tripId
+     * @return
+     */
     private Trip getTrip(Long tripId) {
         return tripRepository
                 .findById(tripId)
-                .orElseThrow(() -> new DefaultException(NO_SUCH_TRIP)
-                );
+                .orElseThrow(() -> new DefaultException(NO_SUCH_TRIP));
     }
 
+    /**
+     * 여정 아이디 리스트 가져와 itinerary 들 삭제하는 메소드
+     * @param tripId
+     * @param deleteIdList
+     * @return
+     */
     @Transactional
     public List<ItineraryResponse> deleteItineraries(
             Long tripId,
             List<Long> deleteIdList
     ) {
-
         //1. 여정들 가져오기 (id만 적힌것들) -> delete 처리
         for (Long id : deleteIdList) {
             Itinerary it = itineraryRepository
@@ -124,30 +181,57 @@ public class ItineraryService {
                     .orElseThrow(() -> new DefaultException(
                             ExceptionCode.NO_ITINERARY
                     ));
-            it.delete(LocalDateTime.now());
-            it.updateDeleted();
+            it.delete();
         }
 
         //2. 남은 여정들의 순서 재정의
         List<Itinerary> itineraries = itineraryRepository
-                .findAllByTripIdAndIsDeletedNull(getTrip(tripId))
+                .findAllByTripAndIsDeletedNull(getTrip(tripId))
                 .orElseGet(ArrayList::new);
 
         Collections.sort(itineraries, Comparator.comparingInt(Itinerary::getItineraryOrder));
 
         List<ItineraryResponse> itineraryResponseList = new ArrayList<>();
+        sortAgainItineraryOrder(itineraries, itineraryResponseList);
+
+        return itineraryResponseList;
+    }
+
+    /**
+     * itinerary 리스트 순서 재정의 및 여정 response List에 담아 반환하는 메소드
+     * @param itineraries
+     * @param itineraryResponseList
+     */
+    private static void sortAgainItineraryOrder(List<Itinerary> itineraries,
+            List<ItineraryResponse> itineraryResponseList
+    ) {
         for (int order = 1; order <= itineraries.size(); order++) {
             //리스트 순대로 order update
             Itinerary it = itineraries.get(order - 1);
             it.updateItineraryOrder(order);
             itineraryResponseList.add(ItineraryResponse.fromEntity(it));
         }
-
-        return itineraryResponseList;
     }
 
+    /**
+     * trip 객체에 연관된 itinerary 들 전부 삭제 처리하는 메소드
+     * @param trip
+     */
+    @Transactional
+    public void deleteAllItineraryByTrip(Trip trip) {
+        for (Itinerary it : getItineraryList(trip)) {
+            it.delete();
+        }
+    }
+
+    /**
+     * itinerary (1개 이상) 수정하는 메소드
+     * @param tripId
+     * @param itineraryUpdateRequests
+     * @return
+     */
     @Transactional(readOnly = false)
-    public List<ItineraryResponse> updateItinerary(Long tripId,
+    public List<ItineraryResponse> updateItineraries(Long tripId,
         List<ItineraryUpdateRequest> itineraryUpdateRequests) {
 
         if (itineraryUpdateRequests == null || itineraryUpdateRequests.isEmpty()) {
@@ -191,13 +275,11 @@ public class ItineraryService {
 
         }
 
-        List<Itinerary> itineraryList = itineraryRepository.findAllByTripIdOrderByItineraryOrder(
+        List<Itinerary> itineraryList = itineraryRepository.findAllByTripOrderByItineraryOrder(
             getTrip(tripId));
 
         ItineraryValidation.validateItinerariesOrder(itineraryList);
-
-        Collections.sort(itineraryResponseList,
-                Comparator.comparingInt(ItineraryResponse::getItineraryOrder));
+        sortItineraryResponseListByOrder(itineraryResponseList);
 
         return itineraryResponseList;
     }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
@@ -49,7 +49,7 @@ public class ItineraryService {
             ItineraryResponse itineraryResponse = null;
 
             switch (ir.getType()) {
-                case 1:
+                case MOVEMENT:
                     itinerary = movementRepository.save(
                             Movement.builder()
                                     .tripId(trip)
@@ -59,16 +59,16 @@ public class ItineraryService {
                                     .arrivalDate(ir.getEndDate())
                                     .departurePlace(ir.getDeparturePlace())
                                     .arrivalPlace(ir.getArrivalPlace())
-                                    .transportation(ir.getName())
+                                    .transportation(ir.getItem())
                                     .build()
                     );
                     itineraryResponse = MovementResponse.fromEntity((Movement) itinerary);
                     break;
-                case 2:
+                case LODGEMENT:
                     itinerary = lodgementRepository.save(
                             Lodgement.builder()
                                     .tripId(trip)
-                                    .itineraryName(ir.getName())
+                                    .itineraryName(ir.getItem())
                                     .itineraryOrder(ir.getOrder())
                                     .checkIn(ir.getStartDate())
                                     .checkOut(ir.getEndDate())
@@ -76,11 +76,11 @@ public class ItineraryService {
                     );
                     itineraryResponse = LodgementResponse.fromEntity((Lodgement) itinerary);
                     break;
-                case 3:
+                case STAY:
                     itinerary = stayRepository.save(
                             Stay.builder()
                                     .tripId(trip)
-                                    .itineraryName(ir.getName())
+                                    .itineraryName(ir.getItem())
                                     .itineraryOrder(ir.getOrder())
                                     .departureDate(ir.getStartDate())
                                     .arrivalDate(ir.getEndDate())
@@ -159,7 +159,7 @@ public class ItineraryService {
         for (ItineraryUpdateRequest req : itineraryUpdateRequests) {
 
             switch (req.getType()) {
-                case 1:
+                case MOVEMENT:
                     Movement movement = movementRepository.findById(req.getItineraryId())
                         .orElseThrow(
                             () -> new DefaultException(ExceptionCode.NO_ITINERARY));
@@ -168,7 +168,7 @@ public class ItineraryService {
                     itineraryResponseList.add(ItineraryResponse.fromEntity(movement));
 
                     break;
-                case 2:
+                case LODGEMENT:
                     Lodgement lodgement = lodgementRepository.findById(req.getItineraryId())
                         .orElseThrow(
                             () -> new DefaultException(ExceptionCode.NO_ITINERARY));
@@ -177,7 +177,7 @@ public class ItineraryService {
                     itineraryResponseList.add(ItineraryResponse.fromEntity(lodgement));
 
                     break;
-                case 3:
+                case STAY:
                     Stay stay = stayRepository.findById(req.getItineraryId()).orElseThrow(
                         () -> new DefaultException(ExceptionCode.NO_SUCH_TRIP));
 
@@ -195,6 +195,9 @@ public class ItineraryService {
             getTrip(tripId));
 
         ItineraryValidation.validateItinerariesOrder(itineraryList);
+
+        Collections.sort(itineraryResponseList,
+                Comparator.comparingInt(ItineraryResponse::getItineraryOrder));
 
         return itineraryResponseList;
     }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/type/ItineraryType.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/type/ItineraryType.java
@@ -1,0 +1,15 @@
+package com.fastcampus.toyproject.domain.itinerary.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ItineraryType {
+    MOVEMENT("이동"),
+    LODGEMENT("숙박"),
+    STAY("체류")
+    ;
+    private String value;
+
+}

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/controller/TripController.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/controller/TripController.java
@@ -2,15 +2,14 @@ package com.fastcampus.toyproject.domain.trip.controller;
 
 
 import com.fastcampus.toyproject.common.dto.ResponseDTO;
+import com.fastcampus.toyproject.common.util.DateUtil;
 import com.fastcampus.toyproject.domain.trip.dto.TripDetailDTO;
 import com.fastcampus.toyproject.domain.trip.dto.TripRequestDTO;
 import com.fastcampus.toyproject.domain.trip.dto.TripResponseDTO;
 import com.fastcampus.toyproject.domain.trip.service.TripService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
@@ -23,9 +22,10 @@ public class TripController {
     @GetMapping("/trips")
     public ResponseDTO<List<TripResponseDTO>> getAllTrips(){
         return ResponseDTO.ok
-            ("모든 Trip들을 가져왔습니다.",tripService.getAllTrips()
+            ("모든 Trip들을 가져왔습니다.", tripService.getAllTrips()
             );
     }
+
 
     @GetMapping("/trips/{tripId}")
     public ResponseDTO<TripDetailDTO> getTripDetail(
@@ -39,6 +39,7 @@ public class TripController {
     @PostMapping
     public ResponseDTO<TripResponseDTO> insertTrip(@PathVariable Long memberId,
         @RequestBody TripRequestDTO tripRequestDTO) {
+        DateUtil.isStartDateEarlierThanEndDate(tripRequestDTO.getStartDate(), tripRequestDTO.getEndDate());
         TripResponseDTO savedTrip = tripService.insertTrip(memberId, tripRequestDTO);
         return ResponseDTO.ok("Trip이 성공적으로 저장되었습니다.", savedTrip);
     }
@@ -48,6 +49,7 @@ public class TripController {
         @PathVariable Long memberId,
         @PathVariable Long tripId,
         @RequestBody TripRequestDTO tripRequestDTO) {
+        DateUtil.isStartDateEarlierThanEndDate(tripRequestDTO.getStartDate(), tripRequestDTO.getEndDate());
         TripResponseDTO updatedTrip = tripService.updateTrip(memberId, tripId, tripRequestDTO);
         return ResponseDTO.ok("Trip이 성공적으로 업데이트되었습니다.", updatedTrip);
     }

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/entity/Trip.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/entity/Trip.java
@@ -1,11 +1,15 @@
 package com.fastcampus.toyproject.domain.trip.entity;
 
 import com.fastcampus.toyproject.common.BaseTimeEntity;
+import com.fastcampus.toyproject.domain.itinerary.entity.Itinerary;
 import com.fastcampus.toyproject.domain.member.entity.Member;
 import com.fastcampus.toyproject.domain.trip.dto.TripRequestDTO;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
@@ -15,6 +19,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -55,14 +60,17 @@ public class Trip extends BaseTimeEntity {
     @ColumnDefault("false")
     private boolean isDeleted;
 
+    @OneToMany(mappedBy = "trip", cascade = {CascadeType.ALL}, fetch = FetchType.EAGER, orphanRemoval = true)
+    List<Itinerary> itineraryList = new ArrayList<>();
+    //CascadeType.ALL -> 상위 객체 작업 하위객체 모두한테 전파.
+    //fetch = FetchType.EAGER -> 실제 조회할 때 한방 쿼리로 다 조회.(itinerary을 사용할 때 쿼리 안나가도 된다.)
+    //orphanRemoval = true -> 부모가 자식에 대한 참조를 끊을 때, 참조가 끊어진 자식 Entity(고아 객체)를 DB에서 삭제하도록 설정할 수 있다.
+    //우리는 soft delete 이므로 굳이 필요는 없음.
 
-    public void setIsDeleted(boolean isDeleted) {
-        this.isDeleted = isDeleted;
-    }
 
-    @Override
-    public void delete(LocalDateTime currentTime) {
-        super.delete(currentTime);
+    public void delete() {
+        super.delete(LocalDateTime.now());
+        this.isDeleted = true;
     }
 
     public void updateFromDTO(TripRequestDTO tripDTO) {

--- a/src/test/java/com/fastcampus/toyproject/http_requests/itinerary-create.http
+++ b/src/test/java/com/fastcampus/toyproject/http_requests/itinerary-create.http
@@ -1,4 +1,4 @@
-POST http://localhost:8080/itineraries/5
+POST http://localhost:8080/itineraries/1
 Content-Type: application/json
 
 [
@@ -6,7 +6,7 @@ Content-Type: application/json
     "type" : "MOVEMENT",
     "item" : "비행기",
     "startDate" : "2023-10-25T17:03:10",
-    "endDate" : "2023-10-25T17:03:10",
+    "endDate" : "2023-10-24T00:00:10",
     "order" : 1,
     "departurePlace" : "인천 공항",
     "arrivalPlace" : "도쿄 공항"
@@ -14,15 +14,15 @@ Content-Type: application/json
   {
     "type" : "STAY",
     "item" : "디즈니월드",
-    "startDate" : "2023-10-25T17:03:10",
-    "endDate" : "2023-10-25T17:03:10",
-    "order" : 2
+    "startDate" : "2023-10-26T12:00:10",
+    "endDate" : "2023-10-26T20:03:10",
+    "order" : 1
   },
   {
     "type" : "LODGEMENT",
     "item" : "도쿄 호텔",
     "startDate" : "2023-10-25T17:03:10",
-    "endDate" : "2023-10-25T17:03:10",
+    "endDate" : "2023-10-29T10:03:10",
     "order" : 3
   }
 ]

--- a/src/test/java/com/fastcampus/toyproject/http_requests/itinerary-create.http
+++ b/src/test/java/com/fastcampus/toyproject/http_requests/itinerary-create.http
@@ -1,10 +1,10 @@
-POST http://localhost:8080/itineraries/1
+POST http://localhost:8080/itineraries/5
 Content-Type: application/json
 
 [
   {
-    "type" : 1,
-    "name" : "비행기",
+    "type" : "MOVEMENT",
+    "item" : "비행기",
     "startDate" : "2023-10-25T17:03:10",
     "endDate" : "2023-10-25T17:03:10",
     "order" : 1,
@@ -12,15 +12,15 @@ Content-Type: application/json
     "arrivalPlace" : "도쿄 공항"
   },
   {
-    "type" : 3,
-    "name" : "디즈니월드",
+    "type" : "STAY",
+    "item" : "디즈니월드",
     "startDate" : "2023-10-25T17:03:10",
     "endDate" : "2023-10-25T17:03:10",
     "order" : 2
   },
   {
-    "type" : 2,
-    "name" : "도쿄 호텔",
+    "type" : "LODGEMENT",
+    "item" : "도쿄 호텔",
     "startDate" : "2023-10-25T17:03:10",
     "endDate" : "2023-10-25T17:03:10",
     "order" : 3

--- a/src/test/java/com/fastcampus/toyproject/http_requests/itinerary-delete.http
+++ b/src/test/java/com/fastcampus/toyproject/http_requests/itinerary-delete.http
@@ -2,5 +2,5 @@ PUT http://localhost:8080/itineraries/delete/1
 Content-Type: application/json
 
 [
-  1,3,5
+  1,3
 ]

--- a/src/test/java/com/fastcampus/toyproject/http_requests/itnerary-create2.http
+++ b/src/test/java/com/fastcampus/toyproject/http_requests/itnerary-create2.http
@@ -1,29 +1,29 @@
-POST http://localhost:8080/itineraries/1
+POST http://localhost:8080/itineraries/5
 Content-Type: application/json
 
 [
   {
-    "type" : 1,
-    "name" : "버스",
-    "startDate" : "2023-10-25T17:03:10",
-    "endDate" : "2023-10-25T17:03:10",
-    "order" : 5,
-    "departurePlace" : "도쿄 타워",
-    "arrivalPlace" : "도쿄 디즈니랜드"
+    "type": "MOVEMENT",
+    "item": "버스",
+    "startDate": "2023-10-25T17:03:10",
+    "endDate": "2023-10-25T17:03:10",
+    "order": 5,
+    "departurePlace": "도쿄 타워",
+    "arrivalPlace": "도쿄 디즈니랜드"
   },
   {
-    "type" : 3,
-    "name" : "도쿄 타워",
-    "startDate" : "2023-10-25T17:03:10",
-    "endDate" : "2023-10-25T17:03:10",
-    "order" : 4
+    "type": "STAY",
+    "item": "도쿄 타워",
+    "startDate": "2023-10-25T17:03:10",
+    "endDate": "2023-10-25T17:03:10",
+    "order": 4
   },
   {
-    "type" : 2,
-    "name" : "도쿄 온천있는 호텔",
-    "startDate" : "2023-10-25T17:03:10",
-    "endDate" : "2023-10-25T17:03:10",
-    "order" : 6
+    "type": "LODGEMENT",
+    "item": "도쿄 온천있는 호텔",
+    "startDate": "2023-10-25T17:03:10",
+    "endDate": "2023-10-25T17:03:10",
+    "order": 6
   }
 ]
 

--- a/src/test/java/com/fastcampus/toyproject/http_requests/trip-create.http
+++ b/src/test/java/com/fastcampus/toyproject/http_requests/trip-create.http
@@ -1,10 +1,10 @@
-POST http://localhost:8080/api/trip/1
+POST http://localhost:8080/api/member/1/trip
 Content-Type: application/json
 
 {
   "memberId" : 1,
   "tripName" : "일본 여행",
-  "startDate" : "2023-10-25T17:03:10",
-  "endDate" : "2023-10-25T17:03:10",
+  "startDate" : "2023-10-04",
+  "endDate" : "2023-10-25",
   "isDomestic" : true
 }


### PR DESCRIPTION
## 개요
여행:여정 관계가 1:n임을 따라서, 여행 entity에 list<여정> 을 추가하였습니다. 
또한 여행, 여정 입력시 날짜 vaild를 하게 했습니다. 
기타 리팩토링 작업을 하였습니다. 
- 여정 타입을 enum으로 두어 관리하였습니다.
## 작업사항
다음과 같이 추가하였습니다. 
![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/59862752/cfe0122f-2d6c-47e5-b497-c3ee645f5fd4)

테스트 화면
### 여행 전체 조회시
![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/59862752/b17bb849-992f-4bde-ad1d-1d9c44f04fef)

### 여행 상세 조회시
![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/59862752/19bea0a2-11de-4682-9038-88e488249695)


## 변경로직
### 변경후
1. 여정 관련된 것은 여정 서비스에 몰아넣어, 여행 서비스에서는 여정 서비스 객체를 이용해 상세조회 및 전체조회를 합니다. 
2. 컨트롤러 내부에 여행, 여정 날짜 입력시 출발 < 도착이 되게끔 검증 처리를 넣었습니다. 
3. 리팩토링 하면서 메소드 분리를 하였습니다. 
4. 여정 타입 enum으로 두어 관리하였습니다. 
## 사용방법
## 기타
