### PR TITLE
[refactor] 에러코드 Trip과 Itinerary로 분리

### DIFF
--- a/src/main/java/com/fastcampus/toyproject/common/exception/ExceptionCode.java
+++ b/src/main/java/com/fastcampus/toyproject/common/exception/ExceptionCode.java
@@ -6,20 +6,13 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum ExceptionCode {
-    NO_ITINERARY("해당되는 여정이 없습니다."),
-    DUPLICATE_ITINERARY_ORDER("여정 순서가 중복됩니다."),
+
     INCORRECT_ORDER("잘못된 여정 순서입니다."),
     INTERNAL_SERVER_ERROR("서버에 오류가 발생했습니다."),
     BAD_REQUEST("잘못된 입력값 입니다."),
     INVALID_REQUEST("잘못된 요청입니다."),
-    NO_SUCH_TRIP("해당하는 Trip이 없습니다."),
-    EMPTY_ITINERARY("수정 할 여정 정보가 없습니다."),
-    ILLEGAL_ARGUMENT_DEPARTUREPLACE("출발지를 입력하지 않았습니다."),
-    ILLEGAL_ARGUMENT_ARRIVALPLACE("도착지를 입력하지 않았습니다."),
-    STARTDATE_IS_LATER_THAN_ENDDATE("출발 일정이 도착 일정보다 늦습니다."),
-    ILLEGAL_ITINERARY_TYPE("잘 못 된 여정 타입입니다.")
-  
+
     ;
 
-    private String msg;
+    private final String msg;
 }

--- a/src/main/java/com/fastcampus/toyproject/common/exception/ExceptionCode.java
+++ b/src/main/java/com/fastcampus/toyproject/common/exception/ExceptionCode.java
@@ -7,10 +7,11 @@ import lombok.Getter;
 @Getter
 public enum ExceptionCode {
 
-    INCORRECT_ORDER("잘못된 여정 순서입니다."),
+
     INTERNAL_SERVER_ERROR("서버에 오류가 발생했습니다."),
     BAD_REQUEST("잘못된 입력값 입니다."),
     INVALID_REQUEST("잘못된 요청입니다."),
+    STARTDATE_IS_LATER_THAN_ENDDATE("출발 일정이 도착 일정보다 늦습니다."),
 
     ;
 

--- a/src/main/java/com/fastcampus/toyproject/common/util/DateUtil.java
+++ b/src/main/java/com/fastcampus/toyproject/common/util/DateUtil.java
@@ -1,11 +1,11 @@
 package com.fastcampus.toyproject.common.util;
 
-import static com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExceptionCode.STARTDATE_IS_LATER_THAN_ENDDATE;
+import static com.fastcampus.toyproject.common.exception.ExceptionCode.STARTDATE_IS_LATER_THAN_ENDDATE;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
-import com.fastcampus.toyproject.domain.itinerary.exception.ItineraryException;
+import com.fastcampus.toyproject.common.exception.DefaultException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -51,13 +51,13 @@ public class DateUtil {
     // 출발 날짜가 도착 날짜보다 빠른지 검사 -> 아니라면 예외 날림
     public static void isStartDateEarlierThanEndDate(LocalDate start, LocalDate end) {
         if (!start.isEqual(end) && start.isAfter(end)) {
-            throw new ItineraryException(STARTDATE_IS_LATER_THAN_ENDDATE);
+            throw new DefaultException(STARTDATE_IS_LATER_THAN_ENDDATE);
         }
     }
 
     public static void isStartDateEarlierThanEndDate(LocalDateTime start, LocalDateTime end) {
         if (!start.isEqual(end) && start.isAfter(end)) {
-            throw new ItineraryException(STARTDATE_IS_LATER_THAN_ENDDATE);
+            throw new DefaultException(STARTDATE_IS_LATER_THAN_ENDDATE);
         }
     }
 

--- a/src/main/java/com/fastcampus/toyproject/common/util/DateUtil.java
+++ b/src/main/java/com/fastcampus/toyproject/common/util/DateUtil.java
@@ -1,12 +1,11 @@
 package com.fastcampus.toyproject.common.util;
 
-import static com.fastcampus.toyproject.common.exception.ExceptionCode.STARTDATE_IS_LATER_THAN_ENDDATE;
+import static com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExceptionCode.STARTDATE_IS_LATER_THAN_ENDDATE;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
-import com.fastcampus.toyproject.common.exception.DefaultException;
-import com.fastcampus.toyproject.common.exception.ExceptionCode;
+import com.fastcampus.toyproject.domain.itinerary.exception.ItineraryException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -52,13 +51,13 @@ public class DateUtil {
     // 출발 날짜가 도착 날짜보다 빠른지 검사 -> 아니라면 예외 날림
     public static void isStartDateEarlierThanEndDate(LocalDate start, LocalDate end) {
         if (!start.isEqual(end) && start.isAfter(end)) {
-            throw new DefaultException(STARTDATE_IS_LATER_THAN_ENDDATE);
+            throw new ItineraryException(STARTDATE_IS_LATER_THAN_ENDDATE);
         }
     }
 
     public static void isStartDateEarlierThanEndDate(LocalDateTime start, LocalDateTime end) {
         if (!start.isEqual(end) && start.isAfter(end)) {
-            throw new DefaultException(STARTDATE_IS_LATER_THAN_ENDDATE);
+            throw new ItineraryException(STARTDATE_IS_LATER_THAN_ENDDATE);
         }
     }
 

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryRequest.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryRequest.java
@@ -1,18 +1,17 @@
 package com.fastcampus.toyproject.domain.itinerary.dto;
 
+import static com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExceptionCode.ILLEGAL_ARGUMENT_ARRIVALPLACE;
+import static com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExceptionCode.ILLEGAL_ARGUMENT_DEPARTUREPLACE;
+
+import com.fastcampus.toyproject.domain.itinerary.exception.ItineraryException;
 import com.fastcampus.toyproject.domain.itinerary.type.ItineraryType;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
-import com.fastcampus.toyproject.common.exception.DefaultException;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
-
-import static com.fastcampus.toyproject.common.exception.ExceptionCode.ILLEGAL_ARGUMENT_ARRIVALPLACE;
-import static com.fastcampus.toyproject.common.exception.ExceptionCode.ILLEGAL_ARGUMENT_DEPARTUREPLACE;
 
 @Getter
 @ToString
@@ -41,10 +40,10 @@ public class ItineraryRequest {
 
     public String getMovementName() {
         if (this.departurePlace == null) {
-            throw new DefaultException(ILLEGAL_ARGUMENT_DEPARTUREPLACE);
+            throw new ItineraryException(ILLEGAL_ARGUMENT_DEPARTUREPLACE);
         }
         if (this.arrivalPlace == null) {
-            throw new DefaultException(ILLEGAL_ARGUMENT_ARRIVALPLACE);
+            throw new ItineraryException(ILLEGAL_ARGUMENT_ARRIVALPLACE);
         }
         return this.departurePlace + " -> " + this.arrivalPlace;
     }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Itinerary.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Itinerary.java
@@ -1,12 +1,11 @@
 package com.fastcampus.toyproject.domain.itinerary.entity;
 
+import static com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExceptionCode.ILLEGAL_ITINERARY_TYPE;
+
 import com.fastcampus.toyproject.common.BaseTimeEntity;
-import com.fastcampus.toyproject.common.exception.DefaultException;
-import com.fastcampus.toyproject.common.exception.ExceptionCode;
 import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryUpdateRequest;
-import com.fastcampus.toyproject.domain.itinerary.type.ItineraryType;
+import com.fastcampus.toyproject.domain.itinerary.exception.ItineraryException;
 import com.fastcampus.toyproject.domain.trip.entity.Trip;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorColumn;
@@ -41,7 +40,7 @@ public class Itinerary extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long itineraryId;
 
-    @ManyToOne(fetch = FetchType.LAZY )
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "tripId")
     private Trip trip;
 
@@ -67,15 +66,15 @@ public class Itinerary extends BaseTimeEntity {
         this.itineraryOrder = newOrder;
     }
 
-    public void update(ItineraryUpdateRequest req){
-        if(this instanceof Movement){
-            ((Movement)this).updateMovement(req);
-        }else if(this instanceof Lodgement){
-            ((Lodgement)this).updateLodgement(req);
-        }else if(this instanceof Stay){
-            ((Stay)this).updateStay(req);
-        }else{
-            throw new DefaultException(ExceptionCode.ILLEGAL_ITINERARY_TYPE);
+    public void update(ItineraryUpdateRequest req) {
+        if (this instanceof Movement) {
+            ((Movement) this).updateMovement(req);
+        } else if (this instanceof Lodgement) {
+            ((Lodgement) this).updateLodgement(req);
+        } else if (this instanceof Stay) {
+            ((Stay) this).updateStay(req);
+        } else {
+            throw new ItineraryException(ILLEGAL_ITINERARY_TYPE);
         }
     }
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/exception/ItineraryException.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/exception/ItineraryException.java
@@ -1,0 +1,23 @@
+package com.fastcampus.toyproject.domain.itinerary.exception;
+
+
+import lombok.Getter;
+
+@Getter
+public class ItineraryException extends RuntimeException {
+
+    ItineraryExceptionCode errorCode;
+    String errorMsg;
+
+    public ItineraryException(ItineraryExceptionCode errorCode, String errorMsg) {
+        super(errorCode.getMsg());
+        this.errorCode = errorCode;
+        this.errorMsg = errorMsg;
+    }
+
+    public ItineraryException(ItineraryExceptionCode errorCode) {
+        super(errorCode.getMsg());
+        this.errorCode = errorCode;
+        this.errorMsg = errorCode.getMsg();
+    }
+}

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/exception/ItineraryExceptionCode.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/exception/ItineraryExceptionCode.java
@@ -8,11 +8,11 @@ import lombok.Getter;
 public enum ItineraryExceptionCode {
 
     NO_ITINERARY("해당되는 여정이 없습니다."),
+    INCORRECT_ITNERARY_ORDER("잘못된 여정 순서입니다."),
     DUPLICATE_ITINERARY_ORDER("여정 순서가 중복됩니다."),
     EMPTY_ITINERARY("수정 할 여정 정보가 없습니다."),
     ILLEGAL_ARGUMENT_DEPARTUREPLACE("출발지를 입력하지 않았습니다."),
     ILLEGAL_ARGUMENT_ARRIVALPLACE("도착지를 입력하지 않았습니다."),
-    STARTDATE_IS_LATER_THAN_ENDDATE("출발 일정이 도착 일정보다 늦습니다."),
     ILLEGAL_ITINERARY_TYPE("잘 못 된 여정 타입입니다.")
 
     ;

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/exception/ItineraryExceptionCode.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/exception/ItineraryExceptionCode.java
@@ -1,0 +1,22 @@
+package com.fastcampus.toyproject.domain.itinerary.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum ItineraryExceptionCode {
+
+    NO_ITINERARY("해당되는 여정이 없습니다."),
+    DUPLICATE_ITINERARY_ORDER("여정 순서가 중복됩니다."),
+    EMPTY_ITINERARY("수정 할 여정 정보가 없습니다."),
+    ILLEGAL_ARGUMENT_DEPARTUREPLACE("출발지를 입력하지 않았습니다."),
+    ILLEGAL_ARGUMENT_ARRIVALPLACE("도착지를 입력하지 않았습니다."),
+    STARTDATE_IS_LATER_THAN_ENDDATE("출발 일정이 도착 일정보다 늦습니다."),
+    ILLEGAL_ITINERARY_TYPE("잘 못 된 여정 타입입니다.")
+
+    ;
+
+    private final String msg;
+
+}

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
@@ -1,10 +1,8 @@
 package com.fastcampus.toyproject.domain.itinerary.service;
 
-import static com.fastcampus.toyproject.common.exception.ExceptionCode.NO_ITINERARY;
-import static com.fastcampus.toyproject.common.exception.ExceptionCode.NO_SUCH_TRIP;
+import static com.fastcampus.toyproject.domain.trip.exception.TripExceptionCode.NO_SUCH_TRIP;
+import static com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExceptionCode.*;
 
-import com.fastcampus.toyproject.common.exception.DefaultException;
-import com.fastcampus.toyproject.common.exception.ExceptionCode;
 import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryRequest;
 import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryResponse;
 import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryUpdateRequest;
@@ -15,12 +13,14 @@ import com.fastcampus.toyproject.domain.itinerary.entity.Itinerary;
 import com.fastcampus.toyproject.domain.itinerary.entity.Lodgement;
 import com.fastcampus.toyproject.domain.itinerary.entity.Movement;
 import com.fastcampus.toyproject.domain.itinerary.entity.Stay;
+import com.fastcampus.toyproject.domain.itinerary.exception.ItineraryException;
 import com.fastcampus.toyproject.domain.itinerary.repository.ItineraryRepository;
 import com.fastcampus.toyproject.domain.itinerary.repository.LodgementRepository;
 import com.fastcampus.toyproject.domain.itinerary.repository.MovementRepository;
 import com.fastcampus.toyproject.domain.itinerary.repository.StayRepository;
 import com.fastcampus.toyproject.domain.itinerary.util.ItineraryOrderUtil;
 import com.fastcampus.toyproject.domain.trip.entity.Trip;
+import com.fastcampus.toyproject.domain.trip.exception.TripException;
 import com.fastcampus.toyproject.domain.trip.repository.TripRepository;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -171,7 +171,7 @@ public class ItineraryService {
     private Trip getTrip(Long tripId) {
         return tripRepository
                 .findById(tripId)
-                .orElseThrow(() -> new DefaultException(NO_SUCH_TRIP));
+                .orElseThrow(() -> new TripException(NO_SUCH_TRIP));
     }
 
     /**
@@ -190,9 +190,7 @@ public class ItineraryService {
         for (Long id : deleteIdList) {
             Itinerary it = itineraryRepository
                     .findById(id)
-                    .orElseThrow(() -> new DefaultException(
-                            ExceptionCode.NO_ITINERARY
-                    ));
+                    .orElseThrow(() -> new ItineraryException(NO_ITINERARY));
             it.delete();
             itineraryRepository.save(it);
             deleteItList.add(ItineraryResponse.fromEntity(it));
@@ -243,7 +241,7 @@ public class ItineraryService {
             List<ItineraryUpdateRequest> itineraryUpdateRequests) {
 
         if (itineraryUpdateRequests == null || itineraryUpdateRequests.isEmpty()) {
-            throw new DefaultException(ExceptionCode.EMPTY_ITINERARY);
+            throw new ItineraryException(EMPTY_ITINERARY);
         }
 
         Trip trip = null;
@@ -252,7 +250,7 @@ public class ItineraryService {
 
 
             Itinerary itinerary = itineraryRepository.findById(req.getItineraryId())
-                .orElseThrow(() -> new DefaultException(NO_ITINERARY));
+                .orElseThrow(() -> new ItineraryException(NO_ITINERARY));
             trip = itinerary.getTrip();
             itinerary.update(req);
         }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryOrderUtil.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryOrderUtil.java
@@ -1,14 +1,13 @@
 package com.fastcampus.toyproject.domain.itinerary.util;
 
-import com.fastcampus.toyproject.common.exception.DefaultException;
 import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryResponse;
 import com.fastcampus.toyproject.domain.itinerary.entity.Itinerary;
 
 import com.fastcampus.toyproject.domain.itinerary.exception.ItineraryException;
 import java.util.*;
 
-import static com.fastcampus.toyproject.common.exception.ExceptionCode.INCORRECT_ORDER;
 import static com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExceptionCode.DUPLICATE_ITINERARY_ORDER;
+import static com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExceptionCode.INCORRECT_ITNERARY_ORDER;
 
 public class ItineraryOrderUtil {
 
@@ -33,7 +32,7 @@ public class ItineraryOrderUtil {
         //2. 순서가 1부터 차례대로 들어갔는지 확인. (O(N))
         for (int orderIdx = 1; orderIdx <= itineraryList.size(); orderIdx++) {
             if (itineraryList.get(orderIdx - 1).getItineraryOrder() != orderIdx) {
-                throw new DefaultException(INCORRECT_ORDER);
+                throw new ItineraryException(INCORRECT_ITNERARY_ORDER);
             }
         }
     }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryOrderUtil.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryOrderUtil.java
@@ -4,10 +4,11 @@ import com.fastcampus.toyproject.common.exception.DefaultException;
 import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryResponse;
 import com.fastcampus.toyproject.domain.itinerary.entity.Itinerary;
 
+import com.fastcampus.toyproject.domain.itinerary.exception.ItineraryException;
 import java.util.*;
 
-import static com.fastcampus.toyproject.common.exception.ExceptionCode.DUPLICATE_ITINERARY_ORDER;
 import static com.fastcampus.toyproject.common.exception.ExceptionCode.INCORRECT_ORDER;
+import static com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExceptionCode.DUPLICATE_ITINERARY_ORDER;
 
 public class ItineraryOrderUtil {
 
@@ -20,7 +21,7 @@ public class ItineraryOrderUtil {
         //1. 순서가 중복되는지 검사하고, 순서대로 정렬. (O(NlogN))
         Collections.sort(itineraryList, (o1, o2) -> {
             if (o1.getItineraryOrder() == o2.getItineraryOrder()) {
-                throw new DefaultException(DUPLICATE_ITINERARY_ORDER);
+                throw new ItineraryException(DUPLICATE_ITINERARY_ORDER);
             }
             return o1.getItineraryOrder()- o2.getItineraryOrder();
         });

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/exception/TripException.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/exception/TripException.java
@@ -1,0 +1,23 @@
+package com.fastcampus.toyproject.domain.trip.exception;
+
+
+import lombok.Getter;
+
+@Getter
+public class TripException extends RuntimeException {
+
+    TripExceptionCode errorCode;
+    String errorMsg;
+
+    public TripException(TripExceptionCode errorCode, String errorMsg) {
+        super(errorCode.getMsg());
+        this.errorCode = errorCode;
+        this.errorMsg = errorMsg;
+    }
+
+    public TripException(TripExceptionCode errorCode) {
+        super(errorCode.getMsg());
+        this.errorCode = errorCode;
+        this.errorMsg = errorCode.getMsg();
+    }
+}

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/exception/TripExceptionCode.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/exception/TripExceptionCode.java
@@ -1,0 +1,15 @@
+package com.fastcampus.toyproject.domain.trip.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum TripExceptionCode {
+    NO_SUCH_TRIP("해당하는 Trip이 없습니다.")
+
+    ;
+
+    private final String msg;
+
+}

--- a/src/main/java/com/fastcampus/toyproject/domain/trip/service/TripService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/trip/service/TripService.java
@@ -1,11 +1,10 @@
 package com.fastcampus.toyproject.domain.trip.service;
 
-import static com.fastcampus.toyproject.common.exception.ExceptionCode.NO_SUCH_TRIP;
+
+import static com.fastcampus.toyproject.domain.trip.exception.TripExceptionCode.NO_SUCH_TRIP;
 
 import com.fastcampus.toyproject.common.exception.DefaultException;
 import com.fastcampus.toyproject.common.exception.ExceptionCode;
-import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryResponse;
-import com.fastcampus.toyproject.domain.itinerary.entity.Itinerary;
 import com.fastcampus.toyproject.domain.itinerary.service.ItineraryService;
 import com.fastcampus.toyproject.domain.member.entity.Member;
 import com.fastcampus.toyproject.domain.member.repository.MemberRepository;
@@ -13,6 +12,7 @@ import com.fastcampus.toyproject.domain.trip.dto.TripDetailResponse;
 import com.fastcampus.toyproject.domain.trip.dto.TripRequest;
 import com.fastcampus.toyproject.domain.trip.dto.TripResponse;
 import com.fastcampus.toyproject.domain.trip.entity.Trip;
+import com.fastcampus.toyproject.domain.trip.exception.TripException;
 import com.fastcampus.toyproject.domain.trip.repository.TripRepository;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -42,7 +42,7 @@ public class TripService {
     public Trip getTripByTripId(Long tripId) {
         return tripRepository
             .findById(tripId)
-            .orElseThrow(() -> new DefaultException(NO_SUCH_TRIP));
+            .orElseThrow(() -> new TripException(NO_SUCH_TRIP));
     }
 
     /**

--- a/src/test/java/com/fastcampus/toyproject/common/util/DateUtilTest.java
+++ b/src/test/java/com/fastcampus/toyproject/common/util/DateUtilTest.java
@@ -1,6 +1,7 @@
 package com.fastcampus.toyproject.common.util;
 
 import com.fastcampus.toyproject.common.exception.DefaultException;
+import com.fastcampus.toyproject.domain.itinerary.exception.ItineraryException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
@@ -28,7 +29,7 @@ class DateUtilTest {
             LocalDate endD = LocalDate.of(2023, 10, 22);
 
             DateUtil.isStartDateEarlierThanEndDate(endD, startD);
-        } catch (DefaultException e) {
+        } catch (ItineraryException e) {
             System.out.println(e.getErrorCode() + ": " + e.getErrorMsg());
         }
     }
@@ -41,7 +42,7 @@ class DateUtilTest {
 
             //DateUtil.isStartDateEarlierThanEndDate(startDt, endDt);
             DateUtil.isStartDateEarlierThanEndDate(endDt, startDt);
-        } catch (DefaultException e) {
+        } catch (ItineraryException e) {
             System.out.println(e.getErrorCode() + ": " + e.getErrorMsg());
         }
     }

--- a/src/test/java/com/fastcampus/toyproject/common/util/DateUtilTest.java
+++ b/src/test/java/com/fastcampus/toyproject/common/util/DateUtilTest.java
@@ -29,7 +29,7 @@ class DateUtilTest {
             LocalDate endD = LocalDate.of(2023, 10, 22);
 
             DateUtil.isStartDateEarlierThanEndDate(endD, startD);
-        } catch (ItineraryException e) {
+        } catch (DefaultException e) {
             System.out.println(e.getErrorCode() + ": " + e.getErrorMsg());
         }
     }
@@ -42,7 +42,7 @@ class DateUtilTest {
 
             //DateUtil.isStartDateEarlierThanEndDate(startDt, endDt);
             DateUtil.isStartDateEarlierThanEndDate(endDt, startDt);
-        } catch (ItineraryException e) {
+        } catch (DefaultException e) {
             System.out.println(e.getErrorCode() + ": " + e.getErrorMsg());
         }
     }

--- a/src/test/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryOrderUtilTest.java
+++ b/src/test/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryOrderUtilTest.java
@@ -10,8 +10,8 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.fastcampus.toyproject.common.exception.ExceptionCode.INCORRECT_ORDER;
 import static com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExceptionCode.DUPLICATE_ITINERARY_ORDER;
+import static com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExceptionCode.INCORRECT_ITNERARY_ORDER;
 
 class ItineraryOrderUtilTest {
 
@@ -55,7 +55,7 @@ class ItineraryOrderUtilTest {
             ItineraryOrderUtil.validateItinerariesOrder(testList2);
         } catch (DefaultException e) {
             //where
-            Assertions.assertEquals(INCORRECT_ORDER, e.getErrorCode());
+            Assertions.assertEquals(INCORRECT_ITNERARY_ORDER, e.getErrorCode());
         }
     }
 

--- a/src/test/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryOrderUtilTest.java
+++ b/src/test/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryOrderUtilTest.java
@@ -10,8 +10,8 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.fastcampus.toyproject.common.exception.ExceptionCode.DUPLICATE_ITINERARY_ORDER;
 import static com.fastcampus.toyproject.common.exception.ExceptionCode.INCORRECT_ORDER;
+import static com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExceptionCode.DUPLICATE_ITINERARY_ORDER;
 
 class ItineraryOrderUtilTest {
 


### PR DESCRIPTION
## 개요
기존의 한군데 있던 에러코드와 익셉션을 Trip과 Itienrary로 나눴습니다.

## 변경로직
### 변경전
![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/40512982/f11737b8-bcd2-447e-a629-07c1663ff679)

### 변경후
![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/40512982/56ee9558-850e-45b4-bfd5-e04951c9a3c0)
Default외에 Trip, Itinerary와 관계된 에러는 해당 도메인으로 옮겼습니다.
## 사용방법
## 기타
