### PR TITLE
[refactor] 여정 삽입 리팩토링 + 팩토리 메소드 패턴 / 여정 순서 검증부분 수정 

### DIFF
--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryResponse.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryResponse.java
@@ -1,15 +1,12 @@
 package com.fastcampus.toyproject.domain.itinerary.dto;
 
 import com.fastcampus.toyproject.domain.itinerary.entity.Itinerary;
+import com.fastcampus.toyproject.domain.itinerary.type.ItineraryType;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
-import java.time.LocalDateTime;
 
 @Getter
 @SuperBuilder
@@ -20,13 +17,14 @@ public class ItineraryResponse {
     private Long id;
     private String itineraryName;
     private Integer itineraryOrder;
-    private String itineraryType;
+    private ItineraryType itineraryType;
 
     public static ItineraryResponse fromEntity(Itinerary itinerary) {
         return ItineraryResponse.builder()
                 .id(itinerary.getItineraryId())
                 .itineraryName(itinerary.getItineraryName())
                 .itineraryOrder(itinerary.getItineraryOrder())
+                .itineraryType(itinerary.getItineraryType())
                 .build();
     }
 

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryResponseFactory.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryResponseFactory.java
@@ -9,6 +9,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
+/**
+ * 여정의 타입이 들어오면 그에 따라 response를 반환해주는
+ * 팩토리 패턴을 적용한 클래스
+ */
 public class ItineraryResponseFactory {
     private final static Map<ItineraryType, Function<Itinerary, ItineraryResponse>> map = new HashMap<>();
 

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryResponseFactory.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/ItineraryResponseFactory.java
@@ -1,0 +1,26 @@
+package com.fastcampus.toyproject.domain.itinerary.dto;
+
+import com.fastcampus.toyproject.domain.itinerary.entity.Itinerary;
+import com.fastcampus.toyproject.domain.itinerary.entity.Lodgement;
+import com.fastcampus.toyproject.domain.itinerary.entity.Movement;
+import com.fastcampus.toyproject.domain.itinerary.entity.Stay;
+import com.fastcampus.toyproject.domain.itinerary.type.ItineraryType;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+public class ItineraryResponseFactory {
+    private final static Map<ItineraryType, Function<Itinerary, ItineraryResponse>> map = new HashMap<>();
+
+    static {
+        map.put(ItineraryType.MOVEMENT, (it) -> MovementResponse.fromEntity((Movement) it));
+        map.put(ItineraryType.LODGEMENT, (it) -> LodgementResponse.fromEntity((Lodgement) it));
+        map.put(ItineraryType.STAY, (it) -> StayResponse.fromEntity((Stay) it));
+    }
+
+    public static ItineraryResponse getItineraryResponse(Itinerary it) {
+        Function<Itinerary, ItineraryResponse> function = map.get(it.getItineraryType());
+        return function.apply(it);
+    }
+
+}

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/LodgementResponse.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/LodgementResponse.java
@@ -26,7 +26,7 @@ public class LodgementResponse extends ItineraryResponse{
                 .id(entity.getItineraryId())
                 .itineraryName(entity.getItineraryName())
                 .itineraryOrder(entity.getItineraryOrder())
-                .itineraryType(LODGEMENT.getValue())
+                .itineraryType(entity.getItineraryType())
                 .checkIn(entity.getCheckIn())
                 .checkOut(entity.getCheckOut())
                 .dayDifference(DateUtil.getDaysBetweenDate(entity.getCheckIn(), entity.getCheckOut()))

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/MovementResponse.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/MovementResponse.java
@@ -29,7 +29,7 @@ public class MovementResponse extends ItineraryResponse {
                 .id(entity.getItineraryId())
                 .itineraryName(entity.getItineraryName())
                 .itineraryOrder(entity.getItineraryOrder())
-                .itineraryType(MOVEMENT.getValue())
+                .itineraryType(entity.getItineraryType())
                 .departureDate(entity.getDepartureDate())
                 .arrivalDate(entity.getArrivalDate())
                 .departurePlace(entity.getDeparturePlace())

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/StayResponse.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/dto/StayResponse.java
@@ -26,7 +26,7 @@ public class StayResponse extends ItineraryResponse {
                 .id(entity.getItineraryId())
                 .itineraryName(entity.getItineraryName())
                 .itineraryOrder(entity.getItineraryOrder())
-                .itineraryType(STAY.getValue())
+                .itineraryType(entity.getItineraryType())
                 .departureDate(entity.getDepartureDate())
                 .arrivalDate(entity.getArrivalDate())
                 .timeDifference(DateUtil.getTimeBetweenDate(entity.getDepartureDate(), entity.getArrivalDate()))

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Itinerary.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/Itinerary.java
@@ -5,12 +5,15 @@ import static com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExce
 import com.fastcampus.toyproject.common.BaseTimeEntity;
 import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryUpdateRequest;
 import com.fastcampus.toyproject.domain.itinerary.exception.ItineraryException;
+import com.fastcampus.toyproject.domain.itinerary.type.ItineraryType;
 import com.fastcampus.toyproject.domain.trip.entity.Trip;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorColumn;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -46,6 +49,10 @@ public class Itinerary extends BaseTimeEntity {
 
     @Column(nullable = false)
     private String itineraryName;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ItineraryType itineraryType;
 
     @Column(nullable = false)
     private Integer itineraryOrder;

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/ItineraryFactory.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/ItineraryFactory.java
@@ -7,6 +7,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiFunction;
 
+/**
+ * request의 여정 타입이 들어오면 그에 따라 entity를 반환해주는
+ * 팩토리 패턴을 적용한 클래스
+ */
 public class ItineraryFactory {
     private final static Map<ItineraryType, BiFunction<Trip,
             ItineraryRequest, Itinerary>> map = new HashMap<>();

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/ItineraryFactory.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/entity/ItineraryFactory.java
@@ -1,0 +1,46 @@
+package com.fastcampus.toyproject.domain.itinerary.entity;
+
+import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryRequest;
+import com.fastcampus.toyproject.domain.itinerary.type.ItineraryType;
+import com.fastcampus.toyproject.domain.trip.entity.Trip;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+public class ItineraryFactory {
+    private final static Map<ItineraryType, BiFunction<Trip,
+            ItineraryRequest, Itinerary>> map = new HashMap<>();
+
+    static {
+        map.put(ItineraryType.MOVEMENT, (trip, ir) ->
+            Movement.builder()
+                    .trip(trip).itineraryName(ir.getMovementName()).itineraryOrder(ir.getOrder())
+                    .itineraryType(ir.getType())
+                    .departureDate(ir.getStartDate()).arrivalDate(ir.getEndDate())
+                    .departurePlace(ir.getDeparturePlace()).arrivalPlace(ir.getArrivalPlace())
+                    .transportation(ir.getItem())
+                    .build()
+        );
+
+        map.put(ItineraryType.LODGEMENT, (trip, ir) ->
+            Lodgement.builder()
+                    .trip(trip).itineraryName(ir.getItem())
+                    .itineraryOrder(ir.getOrder()).itineraryType(ir.getType())
+                    .checkIn(ir.getStartDate()).checkOut(ir.getEndDate())
+                    .build()
+        );
+
+        map.put(ItineraryType.STAY, (trip, ir) ->
+            Stay.builder()
+                    .trip(trip).itineraryName(ir.getItem())
+                    .itineraryOrder(ir.getOrder()).itineraryType(ir.getType())
+                    .departureDate(ir.getStartDate()).arrivalDate(ir.getEndDate())
+                    .build()
+        );
+    }
+
+    public static Itinerary getItineraryEntity(Trip trip, ItineraryRequest ir) {
+        BiFunction<Trip, ItineraryRequest, Itinerary> function = map.get(ir.getType());
+        return function.apply(trip, ir);
+    }
+}

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/repository/ItineraryRepository.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/repository/ItineraryRepository.java
@@ -1,16 +1,10 @@
 package com.fastcampus.toyproject.domain.itinerary.repository;
 
 import com.fastcampus.toyproject.domain.itinerary.entity.Itinerary;
-import com.fastcampus.toyproject.domain.trip.entity.Trip;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface ItineraryRepository extends JpaRepository<Itinerary, Long> {
-    Optional<List<Itinerary>> findAllByTripAndIsDeletedNull(Trip trip);
-
-    List<Itinerary> findAllByTripOrderByItineraryOrder(Trip trip);
 }

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/repository/LodgementRepository.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/repository/LodgementRepository.java
@@ -1,9 +1,0 @@
-package com.fastcampus.toyproject.domain.itinerary.repository;
-
-import com.fastcampus.toyproject.domain.itinerary.entity.Lodgement;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface LodgementRepository extends JpaRepository<Lodgement, Long> {
-}

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/repository/MovementRepository.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/repository/MovementRepository.java
@@ -1,9 +1,0 @@
-package com.fastcampus.toyproject.domain.itinerary.repository;
-
-import com.fastcampus.toyproject.domain.itinerary.entity.Movement;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface MovementRepository extends JpaRepository<Movement, Long> {
-}

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/repository/StayRepository.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/repository/StayRepository.java
@@ -1,9 +1,0 @@
-package com.fastcampus.toyproject.domain.itinerary.repository;
-
-import com.fastcampus.toyproject.domain.itinerary.entity.Stay;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface StayRepository extends JpaRepository<Stay, Long> {
-}

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
@@ -71,13 +71,11 @@ public class ItineraryService {
         0. tripid를 통한 trip 객체 찾기. (method : getTrip(tripId))
         1. 여정 테이블에서 모든 값 가져오기.
         2. 현 request 에서 entity로 변환하여 리스트에 추가.
-        3. 검증 (현재 여정에 저장된거랑 맞는지 확인)
         4. response 리스트 정렬. (오더 순서대로)
          */
         List<ItineraryResponse> itineraryResponseList = new ArrayList<>();
         Trip trip = getTrip(tripId);
 
-        //기존 db에 저장된 값이랑 방금 들어온 요청값의 여정 순서들에 중복없는지 검증하기 위해 리스트 삽입.
         validateItineraryRequestOrder(itineraryRequests, trip);
 
         for (ItineraryRequest ir : itineraryRequests) {
@@ -89,7 +87,8 @@ public class ItineraryService {
                     ItineraryResponseFactory.getItineraryResponse(itinerary)
             );
         }
-        sortItineraryResponseListByOrder(itineraryResponseList);
+
+        ItineraryOrderUtil.sortItineraryResponseListByOrder(itineraryResponseList);
         return itineraryResponseList;
     }
 
@@ -110,8 +109,8 @@ public class ItineraryService {
     }
 
     /**
-     * trip 객체로 연관된 itinerary 리스트를 정렬된 여정 응답 리스트로 변환하여 반환하는 메소드
-     *
+     * trip 객체로 연관된 itinerary response 리스트를
+     * 정렬된 여정 응답 리스트로 변환하여 반환하는 메소드
      * @param trip
      * @return
      */
@@ -125,18 +124,8 @@ public class ItineraryService {
             );
         }
 
-        sortItineraryResponseListByOrder(itineraryResponseList);
+        ItineraryOrderUtil.sortItineraryResponseListByOrder(itineraryResponseList);
         return itineraryResponseList;
-    }
-
-
-    /**
-     * 테이블에 등록된 여정 순서대로 itinerary 리스트 정렬
-     * @param itineraryResponseList
-     */
-    private static void sortItineraryResponseListByOrder(List<ItineraryResponse> itineraryResponseList) {
-        Collections.sort(itineraryResponseList,
-            Comparator.comparingInt(ItineraryResponse::getItineraryOrder));
     }
 
     /**

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/service/ItineraryService.java
@@ -5,19 +5,18 @@ import static com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExce
 
 import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryRequest;
 import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryResponse;
+import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryResponseFactory;
 import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryUpdateRequest;
 import com.fastcampus.toyproject.domain.itinerary.dto.LodgementResponse;
 import com.fastcampus.toyproject.domain.itinerary.dto.MovementResponse;
 import com.fastcampus.toyproject.domain.itinerary.dto.StayResponse;
 import com.fastcampus.toyproject.domain.itinerary.entity.Itinerary;
+import com.fastcampus.toyproject.domain.itinerary.entity.ItineraryFactory;
 import com.fastcampus.toyproject.domain.itinerary.entity.Lodgement;
 import com.fastcampus.toyproject.domain.itinerary.entity.Movement;
 import com.fastcampus.toyproject.domain.itinerary.entity.Stay;
 import com.fastcampus.toyproject.domain.itinerary.exception.ItineraryException;
 import com.fastcampus.toyproject.domain.itinerary.repository.ItineraryRepository;
-import com.fastcampus.toyproject.domain.itinerary.repository.LodgementRepository;
-import com.fastcampus.toyproject.domain.itinerary.repository.MovementRepository;
-import com.fastcampus.toyproject.domain.itinerary.repository.StayRepository;
 import com.fastcampus.toyproject.domain.itinerary.util.ItineraryOrderUtil;
 import com.fastcampus.toyproject.domain.trip.entity.Trip;
 import com.fastcampus.toyproject.domain.trip.exception.TripException;
@@ -37,9 +36,6 @@ public class ItineraryService {
 
     private final TripRepository tripRepository;
     private final ItineraryRepository itineraryRepository;
-    private final LodgementRepository lodgementRepository;
-    private final MovementRepository movementRepository;
-    private final StayRepository stayRepository;
 
 
     /**
@@ -60,7 +56,6 @@ public class ItineraryService {
         return itineraryList;
     }
 
-
     /**
      * itinerary (1개 이상) 삽입하는 메소드
      *
@@ -72,60 +67,46 @@ public class ItineraryService {
     public List<ItineraryResponse> insertItineraries(
             Long tripId, List<ItineraryRequest> itineraryRequests
     ) {
-
+        /*
+        0. tripid를 통한 trip 객체 찾기. (method : getTrip(tripId))
+        1. 여정 테이블에서 모든 값 가져오기.
+        2. 현 request 에서 entity로 변환하여 리스트에 추가.
+        3. 검증 (현재 여정에 저장된거랑 맞는지 확인)
+        4. response 리스트 정렬. (오더 순서대로)
+         */
         List<ItineraryResponse> itineraryResponseList = new ArrayList<>();
-
-        //0. tripid를 통한 trip 객체 찾기. (method : getTrip(tripId))
         Trip trip = getTrip(tripId);
 
-        //1. 여정 테이블에서 모든 값 가져오기.
-        List<Itinerary> itineraries = getItineraryList(trip);
+        //기존 db에 저장된 값이랑 방금 들어온 요청값의 여정 순서들에 중복없는지 검증하기 위해 리스트 삽입.
+        validateItineraryRequestOrder(itineraryRequests, trip);
 
-        //2. 현 request 에서 entity로 변환하여 리스트에 추가.
         for (ItineraryRequest ir : itineraryRequests) {
-            Itinerary itinerary = null;
-            ItineraryResponse itineraryResponse = null;
+            Itinerary itinerary = itineraryRepository.save(
+                    ItineraryFactory.getItineraryEntity(trip, ir)
+            );
 
-            switch (ir.getType()) {
-                case MOVEMENT:
-                    itinerary = movementRepository.save(
-                            Movement.builder().trip(trip).itineraryName(ir.getMovementName())
-                                    .itineraryOrder(ir.getOrder()).departureDate(ir.getStartDate())
-                                    .arrivalDate(ir.getEndDate())
-                                    .departurePlace(ir.getDeparturePlace())
-                                    .arrivalPlace(ir.getArrivalPlace()).transportation(ir.getItem())
-                                    .build()
-                    );
-                    itineraryResponse = MovementResponse.fromEntity((Movement) itinerary);
-                    break;
-                case LODGEMENT:
-                    itinerary = lodgementRepository.save(
-                            Lodgement.builder().trip(trip).itineraryName(ir.getItem())
-                                    .itineraryOrder(ir.getOrder()).checkIn(ir.getStartDate())
-                                    .checkOut(ir.getEndDate()).build()
-                    );
-                    itineraryResponse = LodgementResponse.fromEntity((Lodgement) itinerary);
-                    break;
-                case STAY:
-                    itinerary = stayRepository.save(
-                            Stay.builder().trip(trip).itineraryName(ir.getItem())
-                                    .itineraryOrder(ir.getOrder()).departureDate(ir.getStartDate())
-                                    .arrivalDate(ir.getEndDate()).build()
-                    );
-                    itineraryResponse = StayResponse.fromEntity((Stay) itinerary);
-                    break;
-            }
-            itineraries.add(itinerary);
-            itineraryResponseList.add(itineraryResponse);
+            itineraryResponseList.add(
+                    ItineraryResponseFactory.getItineraryResponse(itinerary)
+            );
         }
-
-        //3. 검증
-        ItineraryOrderUtil.validateItinerariesOrder(itineraries);
-
-        //4. response 리스트 정렬. (오더 순서대로)
         sortItineraryResponseListByOrder(itineraryResponseList);
-
         return itineraryResponseList;
+    }
+
+    /**
+     * 요청으로 들어온 itinerary 리스트의 순서가 맞는지 확인
+     * @param itineraryRequests
+     * @param trip
+     */
+    private void validateItineraryRequestOrder(List<ItineraryRequest> itineraryRequests, Trip trip) {
+        List<Integer> orderList = getItineraryList(trip)
+                .stream().map(Itinerary::getItineraryOrder)
+                .collect(Collectors.toList());
+
+        for (ItineraryRequest ir : itineraryRequests) {
+            orderList.add(ir.getOrder());
+        }
+        ItineraryOrderUtil.validateItinerariesOrder(orderList);
     }
 
     /**
@@ -138,14 +119,10 @@ public class ItineraryService {
         List<Itinerary> itineraryList = getItineraryList(trip);
 
         List<ItineraryResponse> itineraryResponseList = new ArrayList<>();
-        for (Itinerary it : itineraryList) {
-            if (it instanceof Movement) {
-                itineraryResponseList.add(MovementResponse.fromEntity((Movement) it));
-            } else if (it instanceof Lodgement) {
-                itineraryResponseList.add(LodgementResponse.fromEntity((Lodgement) it));
-            } else if (it instanceof Stay) {
-                itineraryResponseList.add(StayResponse.fromEntity((Stay) it));
-            }
+        for (Itinerary itinerary : itineraryList) {
+            itineraryResponseList.add(
+                    ItineraryResponseFactory.getItineraryResponse(itinerary)
+            );
         }
 
         sortItineraryResponseListByOrder(itineraryResponseList);

--- a/src/main/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryOrderUtil.java
+++ b/src/main/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryOrderUtil.java
@@ -16,22 +16,27 @@ public class ItineraryOrderUtil {
      * @param : itineraryList
      * @return
      */
-    public static void validateItinerariesOrder(List<Itinerary> itineraryList) {
+    public static void validateItinerariesOrder(List<Integer> orderList) {
         //1. 순서가 중복되는지 검사하고, 순서대로 정렬. (O(NlogN))
-        Collections.sort(itineraryList, (o1, o2) -> {
-            if (o1.getItineraryOrder() == o2.getItineraryOrder()) {
-                throw new ItineraryException(DUPLICATE_ITINERARY_ORDER);
-            }
-            return o1.getItineraryOrder()- o2.getItineraryOrder();
-        });
-
-        isItinerarySorted(itineraryList);
+        isItineraryOrdersNotDuplicated(orderList);
+        isItineraryOrdersSorted(orderList);
     }
 
-    private static void isItinerarySorted(List<Itinerary> itineraryList) {
+
+    public static void isItineraryOrdersNotDuplicated(List<Integer> orderList) {
+        //1. 순서가 중복되는지 검사하고, 순서대로 정렬. (O(NlogN))
+        Collections.sort(orderList, (o1, o2) -> {
+            if (o1 == o2) {
+                throw new ItineraryException(DUPLICATE_ITINERARY_ORDER);
+            }
+            return o1- o2;
+        });
+    }
+
+    private static void isItineraryOrdersSorted(List<Integer> orderList) {
         //2. 순서가 1부터 차례대로 들어갔는지 확인. (O(N))
-        for (int orderIdx = 1; orderIdx <= itineraryList.size(); orderIdx++) {
-            if (itineraryList.get(orderIdx - 1).getItineraryOrder() != orderIdx) {
+        for (int orderIdx = 1; orderIdx <= orderList.size(); orderIdx++) {
+            if (orderList.get(orderIdx - 1) != orderIdx) {
                 throw new ItineraryException(INCORRECT_ITNERARY_ORDER);
             }
         }

--- a/src/test/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryOrderUtilTest.java
+++ b/src/test/java/com/fastcampus/toyproject/domain/itinerary/util/ItineraryOrderUtilTest.java
@@ -16,7 +16,7 @@ import static com.fastcampus.toyproject.domain.itinerary.exception.ItineraryExce
 class ItineraryOrderUtilTest {
 
     LocalDateTime testStartDate, testEndDate;
-    List<Itinerary> testList1, testList2;
+    List<Integer> testList1, testList2;
 
     public ItineraryOrderUtilTest() {
         this.testList1 = new ArrayList<>();

--- a/src/test/java/com/fastcampus/toyproject/http_requests/itinerary-create.http
+++ b/src/test/java/com/fastcampus/toyproject/http_requests/itinerary-create.http
@@ -5,7 +5,7 @@ Content-Type: application/json
   {
     "type" : "MOVEMENT",
     "item" : "비행기",
-    "startDate" : "2023-10-22T10:03:10",
+    "startDate" : "2023-10-22T12:03:10",
     "endDate" : "2023-10-22T22:00:10",
     "order" : 1,
     "departurePlace" : "인천 공항",

--- a/src/test/java/com/fastcampus/toyproject/http_requests/itinerary-update.http
+++ b/src/test/java/com/fastcampus/toyproject/http_requests/itinerary-update.http
@@ -21,12 +21,12 @@ Content-Type: application/json
     "order": 3
   },
   {
-    "itineraryId": 4,
+    "itineraryId": 3,
     "type": "LODGEMENT",
     "item": "오사카성",
     "startDate": "2023-12-12T17:03:10",
     "endDate": "2023-12-14T17:03:10",
-    "order": 4
+    "order": 2
   }
 ]
 


### PR DESCRIPTION
## 개요
- 여정 삽입을 리팩토링 하였습니다. 
- 여정 순서 검증 부분을 수정하였습니다. 
## 여정 삽입 리팩토링 
### 변경전
여정 삽입 부분은 여정을 이동, 숙박, 체류 빌더를 통해 변경시켜야해서 더러웠어요.
<img width="610" alt="스크린샷 2023-10-28 오후 10 12 40" src="https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/59862752/5dbb7ac4-7d9d-424e-990c-c5cb42f2c210">
### 변경후
팩토리 패턴을 활용한 팩토리 클래스 추가. 
![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/59862752/2cfcc2e7-89dc-42ce-a591-f7df2da398b8)
다음과 같이 깔끔해졌습니다. (response도 같은 방식이용)
![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/59862752/9fe62974-9470-44c7-ba34-986922e28cd3)

## 여정 순서 검증 
### 변경전
만약 순서를 잘못입력함에 따라 빌더를 매번 생성해줘야해서 id 값이 고르지 못했습니다. 
<img width="392" alt="스크린샷 2023-10-28 오후 9 35 57" src="https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/59862752/9d9d8c60-aaa1-4d32-9a3c-60e703c80243">

### 변경후
order를 먼저 검사하도록 로직을 수정하였어요.
id 값이 고르게 들어갑니다. 
<img width="584" alt="스크린샷 2023-10-28 오후 9 53 30" src="https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/59862752/cf22f7a5-f279-466b-99a7-9cb9322fb326">


## 기타

여정, 부분 에러나면 에러 핸들러가 없어서 사용자한테는 서버에서, 로그에는 다음과 같이 나타납니다. 수정이 필요할것 같애요 
<img width="1306" alt="스크린샷 2023-10-28 오후 9 52 23" src="https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/59862752/c20c5fb7-5767-49d2-bc48-4d73cb73ad04">

