### PR TITLE
[test] 여정 컨트롤러 테스트 코드

### DIFF
--- a/src/test/java/com/fastcampus/toyproject/domain/itinerary/controller/ItineraryControllerTest.java
+++ b/src/test/java/com/fastcampus/toyproject/domain/itinerary/controller/ItineraryControllerTest.java
@@ -3,16 +3,14 @@ package com.fastcampus.toyproject.domain.itinerary.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryRequest;
-import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryResponse;
 import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryUpdateRequest;
 import com.fastcampus.toyproject.domain.itinerary.service.ItineraryService;
 import com.fastcampus.toyproject.domain.itinerary.type.ItineraryType;
-import com.fastcampus.toyproject.domain.trip.service.TripService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -20,14 +18,12 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MockMvcBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 @SpringBootTest
@@ -44,18 +40,14 @@ public class ItineraryControllerTest {
 
     private ObjectMapper objectMapper;
 
+    private List<ItineraryUpdateRequest> reqList;
+
     @BeforeEach
-    private void setUup(){
+    private void setup(){
         MockitoAnnotations.initMocks(this);
         this.mockMvc = MockMvcBuilders.standaloneSetup(itineraryController).build();
         this.objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
-    }
-
-
-    @Test
-    public void updateTripTest() throws Exception {
-
-        ItineraryUpdateRequest req = ItineraryUpdateRequest.builder()
+        reqList = List.of(ItineraryUpdateRequest.builder()
             .itineraryId(2L)
             .type(ItineraryType.MOVEMENT)
             .item("로켓")
@@ -64,9 +56,29 @@ public class ItineraryControllerTest {
             .order(3)
             .departurePlace("지구")
             .arrivalPlace("화성")
-            .build();
+            .build());
+    }
 
-        List<ItineraryUpdateRequest> reqList = List.of(req);
+
+    @Test
+    public void insertItineraryTest() throws Exception {
+
+        given(itineraryService.insertItineraries(
+            anyLong(), any()
+        )).willReturn(
+            null
+        );
+
+        mockMvc.perform(post("/api/member/1/trip-itineraries/2")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(reqList)))
+            .andDo(print())
+            .andExpect(status().isOk());
+
+    }
+
+    @Test
+    public void updateItineraryTest() throws Exception {
 
         given(itineraryService.updateItineraries(
             anyLong(), any()
@@ -79,5 +91,21 @@ public class ItineraryControllerTest {
                 .content(objectMapper.writeValueAsString(reqList)))
             .andDo(print())
             .andExpect(status().isOk());
+    }
+
+    @Test
+    public void deleteItienraryTest() throws Exception {
+
+        List<Long> deleteList = List.of(1L, 2L);
+
+        given(itineraryService.deleteItineraries(anyLong(), any()))
+            .willReturn(null);
+
+        mockMvc.perform(put("/api/member/1/trip-itineraries/delete/2")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(deleteList)))
+            .andDo(print())
+            .andExpect(status().isOk());
+
     }
 }

--- a/src/test/java/com/fastcampus/toyproject/domain/itinerary/controller/ItineraryControllerTest.java
+++ b/src/test/java/com/fastcampus/toyproject/domain/itinerary/controller/ItineraryControllerTest.java
@@ -1,0 +1,83 @@
+package com.fastcampus.toyproject.domain.itinerary.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryRequest;
+import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryResponse;
+import com.fastcampus.toyproject.domain.itinerary.dto.ItineraryUpdateRequest;
+import com.fastcampus.toyproject.domain.itinerary.service.ItineraryService;
+import com.fastcampus.toyproject.domain.itinerary.type.ItineraryType;
+import com.fastcampus.toyproject.domain.trip.service.TripService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MockMvcBuilder;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@SpringBootTest
+public class ItineraryControllerTest {
+
+
+    @InjectMocks
+    private ItineraryController itineraryController;
+
+    @Mock
+    private ItineraryService itineraryService;
+
+    private MockMvc mockMvc;
+
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    private void setUup(){
+        MockitoAnnotations.initMocks(this);
+        this.mockMvc = MockMvcBuilders.standaloneSetup(itineraryController).build();
+        this.objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+    }
+
+
+    @Test
+    public void updateTripTest() throws Exception {
+
+        ItineraryUpdateRequest req = ItineraryUpdateRequest.builder()
+            .itineraryId(2L)
+            .type(ItineraryType.MOVEMENT)
+            .item("로켓")
+            .startDate(LocalDateTime.now())
+            .endDate(LocalDateTime.now())
+            .order(3)
+            .departurePlace("지구")
+            .arrivalPlace("화성")
+            .build();
+
+        List<ItineraryUpdateRequest> reqList = List.of(req);
+
+        given(itineraryService.updateItineraries(
+            anyLong(), any()
+        )).willReturn(
+            null
+        );
+
+        mockMvc.perform(put("/api/member/1/trip-itineraries/2")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(reqList)))
+            .andDo(print())
+            .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## 개요
여정의 컨트롤러 테스트를 작성했습니다.

## 작업사항
컨트롤러 테스트는 컨트롤러에서의 로직에만 집중하였으므로 service의 mock객체는 null을 반환하도록 하였습니다.
![image](https://github.com/FC-BE-ToyProject-Team6/KDT_Y_BE_Toy_Project2_DEV/assets/40512982/59baf7b4-5a52-44b1-9d19-f9a1a7377649)


## 기타
